### PR TITLE
Introduce FastAPI server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ Follow these guidelines when contributing:
 - **Testing**: Run available tests before committing. If no tests exist,
   run `python -m py_compile */*.py` and execute the scripts to ensure they
   start without errors.
+- **Server Framework**: The API uses FastAPI served by uvicorn. Add new
+  endpoints via routers in `server/app.py` to keep the application modular.
 
 General workflow:
 1. Create a feature branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Added architecture overview in `docs/architecture.md` and updated
   documentation references.
+- Migrated server to FastAPI with uvicorn and added module routers.
+- Added `requirements.txt` with development dependencies.
+- Updated documentation to reflect new server startup instructions.
 
 ## [0.1.0] - 2025-07-01
 - Initial project structure with server, client, and documentation directories.

--- a/POSTERITY.md
+++ b/POSTERITY.md
@@ -16,6 +16,12 @@ These notes explain why we follow the guidelines in `AGENTS.md`.
   solutions while still supporting personal libraries.
 - **Security** is prioritized by running services with minimal privileges and
   limiting network exposure.
+- **FastAPI and uvicorn** were selected for the server implementation due to
+  their lightweight footprint and strong async support. Running uvicorn through
+  our entry script keeps configuration simple while allowing production
+  deployments to front the service with a reverse proxy for HTTPS termination.
+  Running the API in this manner ensures we can restrict open ports and apply
+  additional security layers such as rate limiting.
 
 These choices support long-term maintainability, scalability, and a secure
 media server environment. Keep this document updated when new decisions are

--- a/README.md
+++ b/README.md
@@ -14,17 +14,21 @@ Shamash is an experimental media server and client. It focuses on IPTV streaming
    git clone https://github.com/yourorg/shamash.git
    cd shamash
    ```
-2. Install dependencies. The server and client currently rely only on the Python standard library, so there is no `requirements.txt` yet. Future versions will document additional dependencies here.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
 
 ## Running the Server
 
-Run the server from the repository root:
+Run the server from the repository root. `server/main.py` launches `uvicorn` to
+serve the FastAPI application:
 
 ```bash
-python server/main.py --port 8000
+python server/main.py --host 0.0.0.0 --port 8000
 ```
 
-The server starts an HTTP service on the given port and serves files from the current directory.
+The server starts an HTTP API on the specified host and port.
 
 ## Running the Client
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,49 @@
+"""FastAPI application for the Shamash media server."""
+
+from fastapi import FastAPI, APIRouter
+
+
+# Placeholder routers for future modules
+media_ingestion_router = APIRouter(prefix="/ingestion", tags=["ingestion"])
+metadata_sync_router = APIRouter(prefix="/metadata", tags=["metadata"])
+user_management_router = APIRouter(prefix="/users", tags=["users"])
+streaming_router = APIRouter(prefix="/stream", tags=["stream"])
+
+
+@media_ingestion_router.get("/ping")
+async def ingestion_ping() -> dict[str, str]:
+    """Check the media ingestion module."""
+    return {"status": "ingestion placeholder"}
+
+
+@metadata_sync_router.get("/ping")
+async def metadata_ping() -> dict[str, str]:
+    """Check the metadata sync module."""
+    return {"status": "metadata placeholder"}
+
+
+@user_management_router.get("/ping")
+async def users_ping() -> dict[str, str]:
+    """Check the user management module."""
+    return {"status": "users placeholder"}
+
+
+@streaming_router.get("/ping")
+async def stream_ping() -> dict[str, str]:
+    """Check the streaming module."""
+    return {"status": "streaming placeholder"}
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+    app = FastAPI(title="Shamash Media Server")
+
+    app.include_router(media_ingestion_router)
+    app.include_router(metadata_sync_router)
+    app.include_router(user_management_router)
+    app.include_router(streaming_router)
+
+    return app
+
+
+app = create_app()

--- a/server/main.py
+++ b/server/main.py
@@ -1,12 +1,20 @@
-"""Simple placeholder web server for Shamash media server."""
+"""Entry point for the Shamash FastAPI server."""
 
 import argparse
-from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+import uvicorn
+
+from app import app
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     """Parse command line arguments for server configuration."""
-    parser = argparse.ArgumentParser(description="Start the Shamash server.")
+    parser = argparse.ArgumentParser(description="Start the Shamash API server.")
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="Host address to bind (default: 0.0.0.0)",
+    )
     parser.add_argument(
         "--port",
         type=int,
@@ -16,14 +24,11 @@ def parse_args():
     return parser.parse_args()
 
 
-def run_server(port: int) -> None:
-    """Run a basic HTTP server on the specified port."""
-    server_address = ("", port)
-    httpd = HTTPServer(server_address, SimpleHTTPRequestHandler)
-    print(f"Shamash server running on http://localhost:{port}")
-    httpd.serve_forever()
+def main() -> None:
+    """Run the FastAPI application with uvicorn."""
+    args = parse_args()
+    uvicorn.run(app, host=args.host, port=args.port)
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    run_server(args.port)
+    main()


### PR DESCRIPTION
## Summary
- create FastAPI application with placeholder routers
- run FastAPI via uvicorn from `server/main.py`
- add FastAPI dev dependencies
- document setup and server run commands
- explain FastAPI choice and update contributor guide

## Testing
- `python -m py_compile */*.py`
- `python server/main.py --host 127.0.0.1 --port 8050` *(terminated after launch)*
- `python client/main.py http://localhost:8050`

------
https://chatgpt.com/codex/tasks/task_e_6863b272929c832ba4093ae86fa5793d