### PR TITLE
Implement basic JWT auth with SQLite backing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ Follow these guidelines when contributing:
   start without errors.
 - **Server Framework**: The API uses FastAPI served by uvicorn. Add new
   endpoints via routers in `server/app.py` to keep the application modular.
+- **Authentication**: JWT utilities live in `server/auth.py`. Use
+  `token_required` as a dependency on protected endpoints. Credentials are
+  stored hashed in the SQLite database managed by `server/db.py`.
 
 General workflow:
 1. Create a feature branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 - Migrated server to FastAPI with uvicorn and added module routers.
 - Added `requirements.txt` with development dependencies.
 - Updated documentation to reflect new server startup instructions.
+- Implemented JWT authentication with `/auth/login` and protected routes.
+- Stored hashed credentials in SQLite via `server/db.py`.
+- Documented token usage and updated contributor guidelines and posterity notes.
 
 ## [0.1.0] - 2025-07-01
 - Initial project structure with server, client, and documentation directories.

--- a/POSTERITY.md
+++ b/POSTERITY.md
@@ -20,8 +20,13 @@ These notes explain why we follow the guidelines in `AGENTS.md`.
   their lightweight footprint and strong async support. Running uvicorn through
   our entry script keeps configuration simple while allowing production
   deployments to front the service with a reverse proxy for HTTPS termination.
-  Running the API in this manner ensures we can restrict open ports and apply
-  additional security layers such as rate limiting.
+Running the API in this manner ensures we can restrict open ports and apply
+additional security layers such as rate limiting.
+
+- **JWT Authentication** was introduced to secure the API while keeping the
+  implementation lightweight. Tokens allow stateless auth so we can scale the
+  service horizontally without session affinity. Storing credentials hashed in
+  SQLite keeps dependencies minimal during early development.
 
 These choices support long-term maintainability, scalability, and a secure
 media server environment. Keep this document updated when new decisions are

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ python server/main.py --host 0.0.0.0 --port 8000
 
 The server starts an HTTP API on the specified host and port.
 
+### Authentication
+
+Create a user in the database using `server/db.py.add_user()` or through a
+future management endpoint. Obtain a token via `/auth/login` and pass it as a
+`Bearer` token when accessing protected routes such as `/stream/ping`.
+
 ## Running the Client
 
 Run the client and specify the server URL if different from the default:

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,9 @@
 This folder contains project documentation. Future design and usage
 information will be stored here. The high-level architecture diagram is
 available in [architecture.md](architecture.md).
+
+## Authentication
+
+Use `/auth/login` to obtain a JWT token. Include the token in the
+`Authorization: Bearer` header when calling protected endpoints such as
+`/stream/ping`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+PyJWT

--- a/server/app.py
+++ b/server/app.py
@@ -1,6 +1,8 @@
 """FastAPI application for the Shamash media server."""
 
-from fastapi import FastAPI, APIRouter
+from fastapi import FastAPI, APIRouter, Depends
+
+from .auth import auth_router, token_required
 
 
 # Placeholder routers for future modules
@@ -29,8 +31,8 @@ async def users_ping() -> dict[str, str]:
 
 
 @streaming_router.get("/ping")
-async def stream_ping() -> dict[str, str]:
-    """Check the streaming module."""
+async def stream_ping(_: str = Depends(token_required)) -> dict[str, str]:
+    """Check the streaming module. Requires a valid token."""
     return {"status": "streaming placeholder"}
 
 
@@ -42,6 +44,7 @@ def create_app() -> FastAPI:
     app.include_router(metadata_sync_router)
     app.include_router(user_management_router)
     app.include_router(streaming_router)
+    app.include_router(auth_router)
 
     return app
 

--- a/server/auth.py
+++ b/server/auth.py
@@ -1,0 +1,70 @@
+"""JWT authentication utilities and route definitions."""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+
+import jwt
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from . import db
+
+
+SECRET_KEY = "change_this_secret"
+ALGORITHM = "HS256"
+TOKEN_EXPIRE_SECONDS = 3600
+
+
+security = HTTPBearer()
+
+auth_router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+class LoginRequest(BaseModel):
+    """Schema for login requests."""
+
+    username: str
+    password: str
+
+
+def create_token(username: str) -> str:
+    """Generate a JWT token for the specified user."""
+    payload = {
+        "sub": username,
+        "exp": datetime.datetime.utcnow() + datetime.timedelta(seconds=TOKEN_EXPIRE_SECONDS),
+    }
+    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def verify_token(token: str) -> str:
+    """Verify a JWT token and return the username."""
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except jwt.PyJWTError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from exc
+    username = payload.get("sub")
+    if username is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+    return username
+
+
+def token_required(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str:
+    """FastAPI dependency that validates a bearer token."""
+    return verify_token(credentials.credentials)
+
+
+@auth_router.post("/login")
+async def login(credentials: LoginRequest) -> dict[str, str]:
+    """Authenticate user credentials and return a JWT token."""
+    username = credentials.username
+    password = credentials.password
+    stored_hash = db.get_password_hash(username)
+    if stored_hash is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    if stored_hash != hashlib.sha256(password.encode()).hexdigest():
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    token = create_token(username)
+    return {"access_token": token}

--- a/server/db.py
+++ b/server/db.py
@@ -1,0 +1,41 @@
+"""Simple SQLite utilities for user authentication."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+
+DB_PATH = Path(__file__).with_name("shamash.db")
+
+
+def get_connection() -> sqlite3.Connection:
+    """Return a connection to the SQLite database."""
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS users (username TEXT PRIMARY KEY, password_hash TEXT)"
+    )
+    return conn
+
+
+def add_user(username: str, password: str) -> None:
+    """Insert a new user with a hashed password."""
+    conn = get_connection()
+    password_hash = hashlib.sha256(password.encode()).hexdigest()
+    with conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO users (username, password_hash) VALUES (?, ?)",
+            (username, password_hash),
+        )
+
+
+def get_password_hash(username: str) -> Optional[str]:
+    """Retrieve the password hash for a username if it exists."""
+    conn = get_connection()
+    cur = conn.execute(
+        "SELECT password_hash FROM users WHERE username = ?", (username,)
+    )
+    row = cur.fetchone()
+    return row[0] if row else None

--- a/server/main.py
+++ b/server/main.py
@@ -4,7 +4,7 @@ import argparse
 
 import uvicorn
 
-from app import app
+from .app import app
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- create `server/auth.py` for JWT token generation and verification
- add lightweight SQLite helper in `server/db.py`
- secure `/stream/ping` with token dependency and expose `/auth/login`
- document authentication usage and reasoning
- mention new workflow in contributor guide and changelog

## Testing
- `python -m py_compile */*.py`
- `python -m server.main --help`

------
https://chatgpt.com/codex/tasks/task_e_6863b3ef01fc832b8cacbcae38882a7f