### PR TITLE
Add local pytest suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,11 @@ Follow these guidelines when contributing:
   `CHANGELOG.md` up to date with your changes.
 - **Commits**: Commit logical units of work with descriptive messages. Update
   the changelog with a brief summary of each change.
-- **Testing**: Run available tests before committing. If no tests exist,
-  run `python -m py_compile */*.py` and execute the scripts to ensure they
-  start without errors.
+- **Testing**: Run `pytest` on the `tests/` directory before committing.
+  Tests are executed locally only and are intentionally omitted from any GitHub
+  workflow. Always create new tests when adding features. If no tests exist,
+  run `python -m py_compile */*.py` and execute the scripts to ensure they start
+  without errors.
 - **Server Framework**: The API uses FastAPI served by uvicorn. Add new
   endpoints via routers in `server/app.py` to keep the application modular.
 - **Authentication**: JWT utilities live in `server/auth.py`. Use
@@ -28,7 +30,8 @@ Follow these guidelines when contributing:
  stored hashed in the SQLite database managed by `server/db.py`.
 - **Database**: A SQLite file `server/shamash.db` stores all data. Import
   `server.db` to create tables automatically using SQLAlchemy models defined in
-  `server/models.py`.
+  `server/models.py`. Set the `SHAMASH_DB_PATH` environment variable to point to
+  an alternate database when running tests.
 
 General workflow:
 1. Create a feature branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 - Documented token usage and updated contributor guidelines and posterity notes.
 - Introduced SQLAlchemy models with basic CRUD utilities and database setup.
 - Updated architecture diagram to illustrate SQLAlchemy-backed SQLite.
+- Established `pytest`-based test suite executed locally only and added
+  `SHAMASH_DB_PATH` override for isolated databases.
 
 ## [0.1.0] - 2025-07-01
 - Initial project structure with server, client, and documentation directories.

--- a/POSTERITY.md
+++ b/POSTERITY.md
@@ -10,6 +10,9 @@ These notes explain why we follow the guidelines in `AGENTS.md`.
   interact and guides scalability planning.
 - **Testing** before committing avoids pushing broken code and maintains
   reliability.
+- **Local Test Execution** keeps the CI pipeline minimal and fast. Developers
+  run tests locally with `pytest` before pushing changes, which prevents
+  workflow slowdowns while still ensuring correctness.
 - **Sonarr/Radarr** are used for movie and series management because they
   are mature tools that integrate well with our workflow.
 - **IPTV Focus** allows Shamash to fill a gap in open source streaming

--- a/README.md
+++ b/README.md
@@ -56,3 +56,15 @@ Provide your IPTV playlist URL and any required credentials through the Shamash 
 
 See the [`docs/`](docs/README.md) directory for additional design notes,
 including a high-level [architecture overview](docs/architecture.md).
+
+## Testing
+
+Run the test suite locally before committing changes. Tests live in the
+`tests/` directory and are executed with:
+
+```bash
+pytest
+```
+
+These tests are not run by any GitHub workflow, so local verification is
+important.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 PyJWT
 SQLAlchemy
+pytest
+httpx

--- a/server/db.py
+++ b/server/db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -11,7 +12,8 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from .models import Base, User, MediaItem
 
-DB_PATH = Path(__file__).with_name("shamash.db")
+DEFAULT_DB_PATH = Path(__file__).with_name("shamash.db")
+DB_PATH = Path(os.environ.get("SHAMASH_DB_PATH", DEFAULT_DB_PATH))
 DATABASE_URL = f"sqlite:///{DB_PATH}"
 
 engine = create_engine(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+import importlib
+import pytest
+
+@pytest.fixture(autouse=True)
+def temp_db(tmp_path):
+    db_file = tmp_path / "test.db"
+    os.environ["SHAMASH_DB_PATH"] = str(db_file)
+    import server.db as db
+    importlib.reload(db)
+    yield db
+    db.engine.dispose()
+    os.environ.pop("SHAMASH_DB_PATH")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,8 @@
+from server.app import create_app
+
+
+def test_app_includes_routes():
+    app = create_app()
+    paths = [route.path for route in app.router.routes]
+    assert "/auth/login" in paths
+    assert "/stream/ping" in paths

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+from server.app import create_app
+from server import db
+
+
+def test_login_success(temp_db):
+    db.add_user("bob", "secret")
+    app = create_app()
+    client = TestClient(app)
+    response = client.post("/auth/login", json={"username": "bob", "password": "secret"})
+    assert response.status_code == 200
+    assert "access_token" in response.json()
+
+
+def test_token_functions():
+    from server.auth import create_token, verify_token
+    token = create_token("carol")
+    assert verify_token(token) == "carol"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,8 @@
+from server import db
+
+
+def test_add_and_get_user(temp_db):
+    user = db.add_user("alice", "password")
+    retrieved = db.get_user("alice")
+    assert retrieved.username == user.username
+    assert db.get_password_hash("alice") == user.password_hash


### PR DESCRIPTION
## Summary
- implement local-only pytest test suite
- allow DB path override via `SHAMASH_DB_PATH`
- document local test workflow in README and AGENTS guidelines
- explain local-only tests in POSTERITY notes
- mention new tests in changelog

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863b749fd18832b8b54d1bc78104072