### PR TITLE
Add Sonarr/Radarr sync integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,11 @@ Follow these guidelines when contributing:
   `server/models.py`. Set the `SHAMASH_DB_PATH` environment variable to point to
   an alternate database when running tests.
 
+- **External API Keys**: Integrations with Sonarr and Radarr require API keys.
+  Set the `SONARR_API_KEY` and `RADARR_API_KEY` environment variables so the
+  server can authenticate to these services. Optionally adjust `SONARR_URL` and
+  `RADARR_URL` if the services run on non-default ports.
+
 General workflow:
 1. Create a feature branch.
 2. Implement changes with proper style and comments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Implemented Sonarr and Radarr integration modules with a new `/metadata/sync`
+  endpoint and client CLI option `--sync-metadata`.
+- Documented external API key setup and updated architecture overview.
 - Added architecture overview in `docs/architecture.md` and updated
   documentation references.
 - Migrated server to FastAPI with uvicorn and added module routers.

--- a/POSTERITY.md
+++ b/POSTERITY.md
@@ -15,6 +15,9 @@ These notes explain why we follow the guidelines in `AGENTS.md`.
   workflow slowdowns while still ensuring correctness.
 - **Sonarr/Radarr** are used for movie and series management because they
   are mature tools that integrate well with our workflow.
+- **Metadata Synchronization** allows Shamash to reuse these managers' rich
+  libraries. Keeping metadata in sync ensures the streaming catalog reflects the
+  latest downloads without reinventing scraping logic.
 - **IPTV Focus** allows Shamash to fill a gap in open source streaming
   solutions while still supporting personal libraries.
 - **Security** is prioritized by running services with minimal privileges and

--- a/client/main.py
+++ b/client/main.py
@@ -28,6 +28,11 @@ def parse_args() -> argparse.Namespace:
         default=get_default_url(),
         help="URL of the Shamash server to connect to",
     )
+    parser.add_argument(
+        "--sync-metadata",
+        action="store_true",
+        help="Trigger metadata synchronization instead of pinging",
+    )
     return parser.parse_args()
 
 
@@ -40,6 +45,20 @@ def ping_server(url: str) -> None:
         print(f"Failed to connect to {url}: {exc}")
 
 
+def sync_metadata(url: str) -> None:
+    """Send a request to synchronize metadata via the server."""
+    endpoint = f"{url.rstrip('/')}/metadata/sync"
+    req = urllib.request.Request(endpoint, method="POST")
+    try:
+        with urllib.request.urlopen(req) as response:
+            print(f"Metadata sync: {response.status}")
+    except Exception as exc:  # Broad except for placeholder simplicity
+        print(f"Failed to sync metadata: {exc}")
+
+
 if __name__ == "__main__":
     args = parse_args()
-    ping_server(args.server_url)
+    if args.sync_metadata:
+        sync_metadata(args.server_url)
+    else:
+        ping_server(args.server_url)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,11 +27,15 @@ A simplified diagram of these interactions is shown below:
           +--------------------+       | Ingestion   |
                  ^                     +-------------+
                  |
-                 +--> Metadata Sync (Sonarr/Radarr)
+                 +--> Metadata Sync
+                              |
+                              +--> Sonarr
+                              +--> Radarr
 ```
 
 The server exposes a REST interface consumed by the client. External services
-like Sonarr and Radarr interact with the metadata module, while the database and
-cache provide state and speed. SQLAlchemy manages the SQLite database so the API
-can evolve without manual SQL changes. Each component can run independently,
-allowing Shamash to scale horizontally.
+Sonarr and Radarr communicate with the metadata module using HTTP requests and
+API keys supplied via environment variables. The database and cache provide
+state and speed. SQLAlchemy manages the SQLite database so the API can evolve
+without manual SQL changes. Each component can run independently, allowing
+Shamash to scale horizontally.

--- a/server/app.py
+++ b/server/app.py
@@ -2,6 +2,9 @@
 
 from fastapi import FastAPI, APIRouter, Depends
 
+from .integrations.radarr import refresh_movies
+from .integrations.sonarr import refresh_series
+
 from .auth import auth_router, token_required
 
 
@@ -22,6 +25,17 @@ async def ingestion_ping() -> dict[str, str]:
 async def metadata_ping() -> dict[str, str]:
     """Check the metadata sync module."""
     return {"status": "metadata placeholder"}
+
+
+@metadata_sync_router.post("/sync")
+async def metadata_sync() -> dict[str, str]:
+    """Synchronize metadata with Sonarr and Radarr."""
+    try:
+        refresh_series()
+        refresh_movies()
+    except Exception as exc:  # Broad except keeps placeholder simple
+        return {"status": f"failed: {exc}"}
+    return {"status": "synchronized"}
 
 
 @user_management_router.get("/ping")

--- a/server/integrations/__init__.py
+++ b/server/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Integration modules for external services."""

--- a/server/integrations/radarr.py
+++ b/server/integrations/radarr.py
@@ -1,0 +1,33 @@
+"""HTTP helpers for interacting with the Radarr API."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+RADARR_URL = os.environ.get("RADARR_URL", "http://localhost:7878")
+RADARR_API_KEY = os.environ.get("RADARR_API_KEY", "")
+
+
+def _headers() -> dict[str, str]:
+    """Return headers required for Radarr requests."""
+    if RADARR_API_KEY:
+        return {"X-Api-Key": RADARR_API_KEY}
+    return {}
+
+
+def get_movies() -> list[dict]:
+    """Retrieve all movies from Radarr."""
+    url = f"{RADARR_URL}/api/v3/movie"
+    response = httpx.get(url, headers=_headers(), timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def refresh_movies() -> None:
+    """Trigger a Radarr refresh command."""
+    url = f"{RADARR_URL}/api/v3/command"
+    payload = {"name": "RefreshMovie"}
+    response = httpx.post(url, json=payload, headers=_headers(), timeout=10)
+    response.raise_for_status()

--- a/server/integrations/sonarr.py
+++ b/server/integrations/sonarr.py
@@ -1,0 +1,33 @@
+"""HTTP helpers for interacting with the Sonarr API."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+SONARR_URL = os.environ.get("SONARR_URL", "http://localhost:8989")
+SONARR_API_KEY = os.environ.get("SONARR_API_KEY", "")
+
+
+def _headers() -> dict[str, str]:
+    """Return headers required for Sonarr requests."""
+    if SONARR_API_KEY:
+        return {"X-Api-Key": SONARR_API_KEY}
+    return {}
+
+
+def get_series() -> list[dict]:
+    """Retrieve all series from Sonarr."""
+    url = f"{SONARR_URL}/api/v3/series"
+    response = httpx.get(url, headers=_headers(), timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def refresh_series() -> None:
+    """Trigger a Sonarr refresh command."""
+    url = f"{SONARR_URL}/api/v3/command"
+    payload = {"name": "RefreshSeries"}
+    response = httpx.post(url, json=payload, headers=_headers(), timeout=10)
+    response.raise_for_status()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,3 +6,4 @@ def test_app_includes_routes():
     paths = [route.path for route in app.router.routes]
     assert "/auth/login" in paths
     assert "/stream/ping" in paths
+    assert "/metadata/sync" in paths


### PR DESCRIPTION
## Summary
- integrate Sonarr and Radarr via new modules
- add metadata sync endpoint and client CLI flag
- document external services and API key configuration
- record reasons for metadata sync
- test new route

## Testing
- `python -m py_compile */*.py server/integrations/*.py`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863b9de3330832bb319934cc80fb835