### PR TITLE
Implement media listing and playback CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,9 @@ Follow these guidelines when contributing:
 - **Configuration**: YAML files in `config/` provide default settings for the
   server and client. Update `config/default.yaml` and `config/client.yaml` when
   introducing new options.
+- **Client CLI**: Use subcommands (`ping`, `sync`, `list`, `play`) implemented
+  with `argparse` in `client/main.py`. Pass `--token` when calling endpoints
+  that require authentication.
 - **Server Framework**: The API uses FastAPI served by uvicorn. Add new
   endpoints via routers in `server/app.py` to keep the application modular.
 - **Authentication**: JWT utilities live in `server/auth.py`. Use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Implemented Sonarr and Radarr integration modules with a new `/metadata/sync`
   endpoint and client CLI option `--sync-metadata`.
+- Added `/media` and `/stream/{id}` endpoints for listing and streaming media
+  items.
+- Enhanced `client/main.py` with `argparse` subcommands (`ping`, `sync`, `list`,
+  `play`) and streaming via external players.
+- Documented new CLI usage and recorded the rationale in POSTERITY.
 - Documented external API key setup and updated architecture overview.
 - Added architecture overview in `docs/architecture.md` and updated
   documentation references.

--- a/POSTERITY.md
+++ b/POSTERITY.md
@@ -42,6 +42,12 @@ additional security layers such as rate limiting.
   the CLI to connect without command line arguments. This structure avoids
   hardcoding paths in code while remaining simple to maintain.
 
+- **CLI Subcommands** were added to make the client extensible. Using
+  `argparse` subparsers keeps the command structure clear as more features are
+  introduced. Streaming support relies on external players like `ffplay` which
+  allows us to avoid embedding complex media libraries while still enabling
+  playback over authenticated HTTP endpoints.
+
 These choices support long-term maintainability, scalability, and a secure
 media server environment. Keep this document updated when new decisions are
 made.

--- a/README.md
+++ b/README.md
@@ -38,13 +38,18 @@ future management endpoint. Obtain a token via `/auth/login` and pass it as a
 
 ## Running the Client
 
-Run the client and specify the server URL if different from the default:
+Use the client subcommands to interact with the server:
 
 ```bash
-python client/main.py http://localhost:8000
-```
+# Ping the API
+python client/main.py ping --server-url http://localhost:8000
 
-The client simply pings the server and prints the HTTP status. It will be expanded in future releases.
+# List available media (requires a token)
+python client/main.py list --token YOUR_TOKEN
+
+# Play an item with ffplay
+python client/main.py play 1 --token YOUR_TOKEN --player ffplay
+```
 
 ## Configuration Files
 

--- a/client/main.py
+++ b/client/main.py
@@ -1,6 +1,9 @@
 """CLI entry point for the Shamash media client."""
 
 import argparse
+import json
+import shutil
+import subprocess
 import urllib.request
 from pathlib import Path
 
@@ -23,16 +26,28 @@ def parse_args() -> argparse.Namespace:
     """Parse command line arguments for client configuration."""
     parser = argparse.ArgumentParser(description="Run the Shamash client.")
     parser.add_argument(
-        "server_url",
-        nargs="?",
+        "--server-url",
         default=get_default_url(),
         help="URL of the Shamash server to connect to",
     )
     parser.add_argument(
-        "--sync-metadata",
-        action="store_true",
-        help="Trigger metadata synchronization instead of pinging",
+        "--token",
+        help="JWT token for authenticated endpoints",
     )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("ping", help="Check server availability")
+    subparsers.add_parser("sync", help="Synchronize metadata")
+    subparsers.add_parser("list", help="List available media items")
+    play_parser = subparsers.add_parser("play", help="Stream a media item")
+    play_parser.add_argument("item_id", type=int, help="ID of media item")
+    play_parser.add_argument(
+        "--player",
+        choices=["ffplay", "vlc"],
+        default="ffplay",
+        help="External player to launch",
+    )
+
     return parser.parse_args()
 
 
@@ -56,9 +71,47 @@ def sync_metadata(url: str) -> None:
         print(f"Failed to sync metadata: {exc}")
 
 
+def list_media(url: str, token: str | None) -> None:
+    """Fetch and display media items from the server."""
+    endpoint = f"{url.rstrip('/')}/media/"
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(endpoint, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as response:
+            items = json.load(response)
+        for item in items:
+            print(f"{item['id']}: {item['title']}")
+    except Exception as exc:  # Broad except for placeholder simplicity
+        print(f"Failed to list media: {exc}")
+
+
+def play_media(url: str, item_id: int, token: str | None, player: str) -> None:
+    """Stream a media item using an external player."""
+    endpoint = f"{url.rstrip('/')}/stream/{item_id}"
+    player_path = shutil.which(player)
+    if player_path is None:
+        print(f"Player '{player}' not found")
+        return
+    cmd = [player_path]
+    if player == "ffplay" and token:
+        cmd.extend(["-headers", f"Authorization: Bearer {token}\r\n"])
+    cmd.append(endpoint)
+    try:
+        subprocess.run(cmd, check=False)
+    except Exception as exc:  # Broad except for placeholder simplicity
+        print(f"Failed to launch player: {exc}")
+
+
 if __name__ == "__main__":
     args = parse_args()
-    if args.sync_metadata:
-        sync_metadata(args.server_url)
-    else:
+
+    if args.command == "ping":
         ping_server(args.server_url)
+    elif args.command == "sync":
+        sync_metadata(args.server_url)
+    elif args.command == "list":
+        list_media(args.server_url, args.token)
+    elif args.command == "play":
+        play_media(args.server_url, args.item_id, args.token, args.player)

--- a/server/app.py
+++ b/server/app.py
@@ -1,9 +1,12 @@
 """FastAPI application for the Shamash media server."""
 
-from fastapi import FastAPI, APIRouter, Depends
+from fastapi import FastAPI, APIRouter, Depends, HTTPException
+from fastapi.responses import FileResponse, RedirectResponse
+from pathlib import Path
 
 from .integrations.radarr import refresh_movies
 from .integrations.sonarr import refresh_series
+from . import db
 
 from .auth import auth_router, token_required
 
@@ -13,6 +16,7 @@ media_ingestion_router = APIRouter(prefix="/ingestion", tags=["ingestion"])
 metadata_sync_router = APIRouter(prefix="/metadata", tags=["metadata"])
 user_management_router = APIRouter(prefix="/users", tags=["users"])
 streaming_router = APIRouter(prefix="/stream", tags=["stream"])
+media_router = APIRouter(prefix="/media", tags=["media"])
 
 
 @media_ingestion_router.get("/ping")
@@ -38,6 +42,16 @@ async def metadata_sync() -> dict[str, str]:
     return {"status": "synchronized"}
 
 
+@media_router.get("/")
+async def list_media(_: str = Depends(token_required)) -> list[dict[str, str]]:
+    """Return all available media items."""
+    items = db.list_media_items()
+    return [
+        {"id": item.id, "title": item.title, "description": item.description}
+        for item in items
+    ]
+
+
 @user_management_router.get("/ping")
 async def users_ping() -> dict[str, str]:
     """Check the user management module."""
@@ -50,6 +64,20 @@ async def stream_ping(_: str = Depends(token_required)) -> dict[str, str]:
     return {"status": "streaming placeholder"}
 
 
+@streaming_router.get("/{item_id}")
+async def stream_media(item_id: int, _: str = Depends(token_required)):
+    """Stream a media file or redirect to a remote URL."""
+    item = db.get_media_item(item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="Media not found")
+    if item.path.startswith("http://") or item.path.startswith("https://"):
+        return RedirectResponse(item.path)
+    file_path = Path(item.path)
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="File not found")
+    return FileResponse(file_path, media_type="application/octet-stream")
+
+
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     app = FastAPI(title="Shamash Media Server")
@@ -57,6 +85,7 @@ def create_app() -> FastAPI:
     app.include_router(media_ingestion_router)
     app.include_router(metadata_sync_router)
     app.include_router(user_management_router)
+    app.include_router(media_router)
     app.include_router(streaming_router)
     app.include_router(auth_router)
 

--- a/server/db.py
+++ b/server/db.py
@@ -110,6 +110,14 @@ def get_media_item(item_id: int) -> Optional[MediaItem]:
     return item
 
 
+def list_media_items() -> list[MediaItem]:
+    """Return all media items."""
+    session = get_session()
+    items = session.scalars(select(MediaItem)).all()
+    session.close()
+    return list(items)
+
+
 def update_media_item(item_id: int, **fields: str) -> bool:
     """Update fields on a media item."""
     session = get_session()

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+from server.app import create_app
+from server import db
+from server.auth import create_token
+
+
+def test_media_list_endpoint(temp_db, tmp_path):
+    db.create_media_item("demo", str(tmp_path / "demo.mp4"))
+    db.add_user("alice", "pw")
+    app = create_app()
+    client = TestClient(app)
+    token = create_token("alice")
+    response = client.get("/media/", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["title"] == "demo"
+
+
+def test_stream_endpoint_serves_file(temp_db, tmp_path):
+    media_file = tmp_path / "sample.txt"
+    media_file.write_text("hello")
+    item = db.create_media_item("sample", str(media_file))
+    db.add_user("bob", "pw")
+    app = create_app()
+    client = TestClient(app)
+    token = create_token("bob")
+    response = client.get(f"/stream/{item.id}", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    assert response.content == b"hello"
+


### PR DESCRIPTION
## Summary
- add new `/media` and `/stream/{id}` endpoints
- extend client with `argparse` subcommands for ping, sync, list and play
- allow streaming media via external player
- document new CLI usage
- record design decisions about CLI subcommands
- add tests for media listing and streaming

## Testing
- `python -m py_compile server/*.py client/*.py tests/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6863bb2f4060832bada70f37b5708e74