### PR TITLE
Improve documentation and troubleshooting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ Follow these guidelines when contributing:
   - `docs/` holds documentation.
   - `docs/architecture.md` contains the high-level architecture diagram. Update
     it when major components or external integrations change.
+  - `docs/README.md` explains each module directory and includes troubleshooting
+    tips. Keep it current as the codebase evolves.
 - **Branching**: Work from short-lived feature branches off `main`. Open a
   pull request when ready for review.
 - **Documentation**: Keep `README.md`, `AGENTS.md`, `POSTERITY.md`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to this project will be documented in this file.
 - Introduced YAML configuration files under `config/` and loader module.
 - Client now reads default server URL from `config/client.yaml`.
 - Documented configuration format and rationale in README and POSTERITY.
+- Expanded README with configuration, authentication and production sections.
+- Documented module directory purposes and troubleshooting tips in `docs/README.md`.
+- Updated AGENTS and POSTERITY to reference the new documentation files.
 
 ## [0.1.0] - 2025-07-01
 - Initial project structure with server, client, and documentation directories.

--- a/POSTERITY.md
+++ b/POSTERITY.md
@@ -47,6 +47,9 @@ additional security layers such as rate limiting.
   introduced. Streaming support relies on external players like `ffplay` which
   allows us to avoid embedding complex media libraries while still enabling
   playback over authenticated HTTP endpoints.
+- **Documentation Overview** in `docs/README.md` guides newcomers by describing
+  each module and capturing troubleshooting steps. Maintaining this file helps
+  reduce onboarding questions.
 
 These choices support long-term maintainability, scalability, and a secure
 media server environment. Keep this document updated when new decisions are

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ python server/main.py --host 0.0.0.0 --port 8000
 
 The server starts an HTTP API on the specified host and port.
 
-### Authentication
+## Authentication
 
 Create a user in the database using `server/db.py.add_user()` or through a
 future management endpoint. Obtain a token via `/auth/login` and pass it as a
@@ -50,6 +50,17 @@ python client/main.py list --token YOUR_TOKEN
 # Play an item with ffplay
 python client/main.py play 1 --token YOUR_TOKEN --player ffplay
 ```
+
+## Configuration
+
+Shamash loads settings from `config/default.yaml`. Edit this file to change
+the listening port, database path or playlist URLs. The CLI reads the default
+server URL from `config/client.yaml`. Environment variables override certain
+settings:
+
+* `SHAMASH_DB_PATH` – path to the SQLite database.
+* `SONARR_API_KEY` and `RADARR_API_KEY` – credentials for Sonarr and Radarr.
+* `SONARR_URL` and `RADARR_URL` – set custom service URLs.
 
 ## Configuration Files
 
@@ -71,6 +82,17 @@ Configure Sonarr and Radarr to download media into directories that Shamash can 
 ## IPTV Configuration
 
 Provide your IPTV playlist URLs in `config/default.yaml`. The server will stream channels from these playlists alongside your local media library.
+
+## Running in Production
+
+Run Shamash behind a reverse proxy such as Nginx for HTTPS termination.
+Start the API using uvicorn directly or under a process manager:
+
+```bash
+uvicorn server.app:app --host 0.0.0.0 --port 8000
+```
+
+Use `systemd` or a similar tool to manage the service and enable restarts.
 
 See the [`docs/`](docs/README.md) directory for additional design notes,
 including a high-level [architecture overview](docs/architecture.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,27 @@ This folder contains project documentation. Future design and usage
 information will be stored here. The high-level architecture diagram is
 available in [architecture.md](architecture.md).
 
+## Directory Overview
+
+* `server/` &ndash; FastAPI backend and database models.
+* `client/` &ndash; Command line client for interacting with the server.
+* `config/` &ndash; YAML configuration for server and client defaults.
+* `docs/` &ndash; Documentation sources including this file.
+* `tests/` &ndash; pytest suite used for local verification.
+
 ## Authentication
 
 Use `/auth/login` to obtain a JWT token. Include the token in the
 `Authorization: Bearer` header when calling protected endpoints such as
 `/stream/ping`.
+
+## Troubleshooting
+
+* **Server fails to start** &ndash; Ensure dependencies are installed with
+  `pip install -r requirements.txt` and that configuration files exist under
+  `config/`.
+* **Sonarr/Radarr unreachable** &ndash; Verify `SONARR_API_KEY` and
+  `RADARR_API_KEY` environment variables are set and the services are
+  accessible at their configured URLs.
+* **`ffplay` not found** &ndash; Install FFmpeg or use `--player` to specify an
+  alternate media player when running the client.

--- a/server/app.py
+++ b/server/app.py
@@ -43,7 +43,7 @@ async def metadata_sync() -> dict[str, str]:
 
 
 @media_router.get("/")
-async def list_media(_: str = Depends(token_required)) -> list[dict[str, str]]:
+async def list_media(_: str = Depends(token_required)) -> list[dict]:
     """Return all available media items."""
     items = db.list_media_items()
     return [


### PR DESCRIPTION
## Summary
- document each module directory and add troubleshooting tips
- add configuration and production guidance in the main README
- clarify docs policy in AGENTS and POSTERITY
- fix type hint for media list endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863bccdd850832b8823cdbae7feb5ec