### PR TITLE
Add login CLI and pin httpx

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,9 +28,11 @@ Follow these guidelines when contributing:
 - **Configuration**: YAML files in `config/` provide default settings for the
   server and client. Update `config/default.yaml` and `config/client.yaml` when
   introducing new options.
-- **Client CLI**: Use subcommands (`ping`, `sync`, `list`, `play`) implemented
-  with `argparse` in `client/main.py`. Pass `--token` when calling endpoints
-  that require authentication.
+- **Client CLI**: Use subcommands (`ping`, `sync`, `list`, `play`, `login`)
+  implemented with `argparse` in `client/main.py`. Pass `--token` when calling
+  endpoints that require authentication. The `login` command posts credentials
+  to `/auth/login` and can store the token in `$HOME/.shamash_token` when using
+  `--save-token`.
 - **Server Framework**: The API uses FastAPI served by uvicorn. Add new
   endpoints via routers in `server/app.py` to keep the application modular.
 - **Authentication**: JWT utilities live in `server/auth.py`. Use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Pinned `httpx` to `<0.24` for compatibility with Starlette 0.27.
+- Added `login` client subcommand with optional token storage.
 - Added `jwt_secret` option in `config/default.yaml` and `JWT_SECRET` environment
   variable for token signing.
 - Replaced SHA-256 password hashing with bcrypt and updated tests.

--- a/POSTERITY.md
+++ b/POSTERITY.md
@@ -6,6 +6,8 @@ These notes explain why we follow the guidelines in `AGENTS.md`.
   and clear naming reduces onboarding time for new contributors.
 - **Documentation** across README and change logs helps track project
   history and design decisions.
+- **Dependency Pinning** avoids unexpected breakage. `httpx` is pinned below
+  version 0.24 to remain compatible with Starlette 0.27.
 - **Architecture Overview** in `docs/architecture.md` illustrates how modules
   interact and guides scalability planning.
 - **Separation of Concerns** is enforced by dividing the codebase into
@@ -63,6 +65,9 @@ additional security layers such as rate limiting.
     introduced. Streaming support relies on external players like `ffplay` which
     allows us to avoid embedding complex media libraries while still enabling
     playback over authenticated HTTP endpoints.
+  - **Login Subcommand** now retrieves tokens from `/auth/login` and can save
+    them to `$HOME/.shamash_token` for convenience. This encourages secure
+    usage without repeatedly passing credentials on the command line.
   - **Containerization** ensures a consistent runtime and simplifies
     deployments. Building the server image from the official Python base allows
     contributors to run the API with identical dependencies. `docker-compose`

--- a/README.md
+++ b/README.md
@@ -44,12 +44,18 @@ Use the client subcommands to interact with the server:
 # Ping the API
 python client/main.py ping --server-url http://localhost:8000
 
+# Obtain a token and save it for later
+python client/main.py login bob secret --save-token
+
 # List available media (requires a token)
 python client/main.py list --token YOUR_TOKEN
 
 # Play an item with ffplay
 python client/main.py play 1 --token YOUR_TOKEN --player ffplay
 ```
+
+The `--save-token` flag writes the returned token to `$HOME/.shamash_token` so
+subsequent commands can pass it via `--token` without retyping.
 
 ## Configuration
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ uvicorn
 PyJWT
 SQLAlchemy
 pytest
-httpx
+httpx<0.24
 PyYAML
 bcrypt

--- a/tests/test_client_login.py
+++ b/tests/test_client_login.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+import urllib.request
+
+from client import main
+
+
+class FakeResponse:
+    def __init__(self, data: bytes):
+        self._data = data
+        self.status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self, *args, **kwargs):
+        return self._data
+
+    def readline(self, *args, **kwargs):
+        return self._data
+
+
+def test_login_saves_token(tmp_path, monkeypatch):
+    responses = []
+
+    def fake_urlopen(req, *args, **kwargs):
+        body = json.loads(req.data.decode())
+        assert body == {"username": "bob", "password": "secret"}
+        responses.append(req.full_url)
+        return FakeResponse(b'{"access_token": "testtoken"}')
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    main.login_user("http://localhost:8000", "bob", "secret", save_token=True)
+
+    token_file = tmp_path / ".shamash_token"
+    assert token_file.exists()
+    assert token_file.read_text(encoding="utf-8") == "testtoken"
+    assert responses == ["http://localhost:8000/auth/login"]


### PR DESCRIPTION
## Summary
- pin httpx under 0.24 for Starlette compatibility
- add `login` subcommand to client with token storage
- document new command in README and AGENTS
- capture reasoning in POSTERITY and CHANGELOG
- test CLI login flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686696303a60832ba339680532065d82