### PR TITLE
Replace placeholder ping endpoints with real health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Pinned `httpx` to `<0.24` for compatibility with Starlette 0.27.
+- Replaced placeholder ping endpoints with database-backed health checks and tests.
 - Added `login` client subcommand with optional token storage.
 - Added `jwt_secret` option in `config/default.yaml` and `JWT_SECRET` environment
   variable for token signing.

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,8 @@
+# Summary
+- Implemented database and external service health checks for all `/ping` endpoints.
+- Added tests ensuring health endpoints return meaningful statuses without placeholders.
+- Documented new health checks in README files and updated the changelog.
+
+# Testing
+- `pytest tests/test_app.py::test_app_includes_routes -q`
+- `pytest -q`

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,10 @@
+# Plan
+
+1. Replace placeholder ping endpoints in `server/app.py` with health checks:
+   - Add helper functions to verify database connectivity and external service reachability.
+   - Update `/ingestion/ping`, `/metadata/ping`, `/users/ping`, and `/stream/ping` to return real statuses.
+2. Update tests to assert new health responses and ensure no placeholder strings remain.
+3. Revise documentation (`README.md`, `docs/README.md`) describing the health endpoints.
+4. Record changes in `CHANGELOG.md`.
+5. Run `pytest tests/test_app.py::test_app_includes_routes -q` and full test suite for verification.
+6. Commit changes and open a pull request.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Create a user in the database using `server/db.py.add_user()` or through a
 future management endpoint. Obtain a token via `/auth/login` and pass it as a
 `Bearer` token when accessing protected routes such as `/stream/ping`.
 
+## Health Endpoints
+
+Shamash exposes several lightweight health checks:
+
+* `GET /ingestion/ping` &ndash; database connectivity for media ingestion.
+* `GET /metadata/ping` &ndash; reachability of Sonarr and Radarr plus database status.
+* `GET /users/ping` &ndash; database connectivity for user management.
+* `GET /stream/ping` &ndash; database connectivity for streaming (requires a token).
+
 ## Running the Client
 
 Use the client subcommands to interact with the server:

--- a/STATE.md
+++ b/STATE.md
@@ -1,0 +1,21 @@
+# Project Invariants
+- R1: Use four spaces for indentation and provide docstrings for modules and functions.
+- R2: Run pytest before committing changes.
+- R3: Update documentation and changelog alongside code modifications.
+
+# Task Requirements
+- T1: Replace placeholder ping endpoints with real health checks.
+- T2: Ensure no placeholder strings remain in responses.
+- T3: Update tests, documentation, and changelog accordingly.
+
+# Cognitive Ledger
+- Cycle 1: Inspected repository structure and existing placeholder endpoints.
+- Cycle 2: Added database and external service health check helpers; replaced placeholder responses.
+- Cycle 3: Expanded tests to verify health endpoints and token-protected stream check.
+- Cycle 4: Updated documentation and changelog with new health endpoints.
+- Cycle 5: Executed targeted and full test suites to confirm functionality.
+
+# Decision Log
+- D1: Chose database `SELECT 1` query to verify connectivity for ingestion, users, and streaming health.
+- D2: Implemented HTTP HEAD requests to Sonarr and Radarr for metadata health without requiring sync commands.
+- D3: Expanded existing test rather than adding new functions to match execution command.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,3 @@
+# Backlog
+- Replace `datetime.utcnow` usage in `server/auth.py` with timezone-aware `datetime.now(datetime.UTC)`.
+- Expand metadata health check to validate API keys and authenticate with external services.

--- a/VERIFICATIONS.md
+++ b/VERIFICATIONS.md
@@ -1,0 +1,7 @@
+# Verification
+
+## `pytest tests/test_app.py::test_app_includes_routes -q`
+- Passed: see chunk `f802b3`.
+
+## `pytest -q`
+- Passed: see chunk `068cd7`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,15 @@ Use `/auth/login` to obtain a JWT token. Include the token in the
 `Authorization: Bearer` header when calling protected endpoints such as
 `/stream/ping`.
 
+## Health Checks
+
+The API exposes lightweight health endpoints:
+
+* `GET /ingestion/ping` &ndash; verifies database connectivity for media ingestion.
+* `GET /metadata/ping` &ndash; checks reachability of Sonarr and Radarr and the database.
+* `GET /users/ping` &ndash; verifies database connectivity for user management.
+* `GET /stream/ping` &ndash; verifies database connectivity for streaming (requires a token).
+
 ### Environment Variables
 
 Set the `JWT_SECRET` variable or edit `config/default.yaml` to configure the

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,9 +1,31 @@
+from fastapi.testclient import TestClient
 from server.app import create_app
+from server import db
 
 
 def test_app_includes_routes():
     app = create_app()
+    client = TestClient(app)
     paths = [route.path for route in app.router.routes]
     assert "/auth/login" in paths
     assert "/stream/ping" in paths
     assert "/metadata/sync" in paths
+
+    db.add_user("alice", "pw")
+    token = client.post(
+        "/auth/login", json={"username": "alice", "password": "pw"}
+    ).json()["access_token"]
+
+    ingest = client.get("/ingestion/ping")
+    assert ingest.json()["status"] in {"ok", "db_unreachable"}
+
+    meta = client.get("/metadata/ping").json()
+    assert "metadata placeholder" not in meta.values()
+
+    user_status = client.get("/users/ping").json()["status"]
+    assert user_status in {"ok", "db_unreachable"}
+
+    stream = client.get(
+        "/stream/ping", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert stream.json()["status"] in {"ok", "db_unreachable"}


### PR DESCRIPTION
## Summary
- add database and external service health checks for ingestion, metadata, users, and streaming modules
- document new health endpoints and update changelog
- verify ping responses via expanded tests

## Testing
- `pytest tests/test_app.py::test_app_includes_routes -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b189a1d85c8322b2fca1151c0547d3