### PR TITLE
Improve client CLI error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
   items.
 - Enhanced `client/main.py` with `argparse` subcommands (`ping`, `sync`, `list`,
   `play`) and streaming via external players.
+- Replaced generic client exception handling with targeted errors and structured
+  logging.
 - Documented new CLI usage and recorded the rationale in POSTERITY.
 - Implemented POST `/ingestion/` and `/users` CRUD endpoints and added tests.
 - Added error handling for Sonarr and Radarr failures with detailed

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,8 +1,6 @@
 # Summary
-- Implemented database and external service health checks for all `/ping` endpoints.
-- Added tests ensuring health endpoints return meaningful statuses without placeholders.
-- Documented new health checks in README files and updated the changelog.
+- Replaced broad client `Exception` handlers with targeted errors and logging.
+- Documented new client error messages and updated the changelog.
 
 # Testing
-- `pytest tests/test_app.py::test_app_includes_routes -q`
-- `pytest -q`
+- `pytest tests/test_client_login.py::test_login_saves_token -q`

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,10 +1,7 @@
 # Plan
 
-1. Replace placeholder ping endpoints in `server/app.py` with health checks:
-   - Add helper functions to verify database connectivity and external service reachability.
-   - Update `/ingestion/ping`, `/metadata/ping`, `/users/ping`, and `/stream/ping` to return real statuses.
-2. Update tests to assert new health responses and ensure no placeholder strings remain.
-3. Revise documentation (`README.md`, `docs/README.md`) describing the health endpoints.
-4. Record changes in `CHANGELOG.md`.
-5. Run `pytest tests/test_app.py::test_app_includes_routes -q` and full test suite for verification.
-6. Commit changes and open a pull request.
+1. Replace generic exception handlers in `client/main.py` with targeted errors and logging.
+2. Document client error messages in `docs/README.md`.
+3. Record the update in `CHANGELOG.md`.
+4. Run `pytest tests/test_client_login.py::test_login_saves_token -q`.
+5. Commit changes and open a pull request.

--- a/STATE.md
+++ b/STATE.md
@@ -4,9 +4,9 @@
 - R3: Update documentation and changelog alongside code modifications.
 
 # Task Requirements
-- T1: Replace placeholder ping endpoints with real health checks.
-- T2: Ensure no placeholder strings remain in responses.
-- T3: Update tests, documentation, and changelog accordingly.
+- T1: Replace generic exception handlers in the client with targeted errors and logging.
+- T2: Document new client error messages in `docs/README.md` and `CHANGELOG.md`.
+- T3: Run `pytest tests/test_client_login.py::test_login_saves_token -q`.
 
 # Cognitive Ledger
 - Cycle 1: Inspected repository structure and existing placeholder endpoints.
@@ -14,8 +14,15 @@
 - Cycle 3: Expanded tests to verify health endpoints and token-protected stream check.
 - Cycle 4: Updated documentation and changelog with new health endpoints.
 - Cycle 5: Executed targeted and full test suites to confirm functionality.
+- Cycle 6: Reviewed client CLI for broad `Exception` handlers.
+- Cycle 7: Introduced specific exception handling with logging in `client/main.py`.
+- Cycle 8: Documented error messages in `docs/README.md` and updated `CHANGELOG.md`.
+- Cycle 9: Ran `pytest tests/test_client_login.py::test_login_saves_token -q`.
+- Cycle 10: Committed changes and prepared pull request.
 
 # Decision Log
 - D1: Chose database `SELECT 1` query to verify connectivity for ingestion, users, and streaming health.
 - D2: Implemented HTTP HEAD requests to Sonarr and Radarr for metadata health without requiring sync commands.
 - D3: Expanded existing test rather than adding new functions to match execution command.
+- D4: Utilized `urllib.error` exceptions and logging for clearer client error reporting.
+- D5: Kept user-facing prints for actionable messages while logging full error details.

--- a/VERIFICATIONS.md
+++ b/VERIFICATIONS.md
@@ -1,7 +1,4 @@
 # Verification
 
-## `pytest tests/test_app.py::test_app_includes_routes -q`
-- Passed: see chunk `f802b3`.
-
-## `pytest -q`
-- Passed: see chunk `068cd7`.
+## `pytest tests/test_client_login.py::test_login_saves_token -q`
+- Passed: see chunk `434fcb`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,3 +46,7 @@ also be provided when using metadata synchronization.
   details and retry once the external services are reachable.
 * **`ffplay` not found** &ndash; Install FFmpeg or use `--player` to specify an
   alternate media player when running the client.
+* **Client connection or login errors** &ndash; The CLI prints specific messages
+  such as `Failed to connect to http://localhost:8000` or `Failed to login:
+  invalid JSON response`. Review the message to resolve network issues,
+  credentials, or file permissions.


### PR DESCRIPTION
## Summary
- replace broad `Exception` blocks in client CLI with specific `urllib.error`, `json`, and `OSError` handlers
- add logging and user-facing messages for connection, sync, list, login, and player errors
- document new CLI error outputs in docs and changelog

## Testing
- `pytest tests/test_client_login.py::test_login_saves_token -q`


------
https://chatgpt.com/codex/tasks/task_b_68b18c83e1f88322bb0e64799e08a942