### PR TITLE
Use timezone-aware JWT expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
 - Documented new CLI usage and recorded the rationale in POSTERITY.
 - Implemented POST `/ingestion/` and `/users` CRUD endpoints and added tests.
 - Added role-based access control with admin-only user management routes.
+- Updated JWT token creation to use timezone-aware UTC timestamps for
+  consistent expiry evaluation.
 - Added error handling for Sonarr and Radarr failures with detailed
   `/metadata/sync` responses.
 - Documented failure modes and updated architecture overview.

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,7 +1,7 @@
 # Summary
-- Added `role` column to users with migration and CRUD support.
-- Enforced admin-only access on user management routes via `require_role` dependency.
-- Documented roles in README and SECURITY guidelines and updated tests.
+- Replaced JWT expiration timestamp generation with timezone-aware `datetime.now(datetime.UTC)`.
+- Added an authentication test asserting expired tokens raise a 401 via `verify_token`.
+- Documented the timezone-aware authentication update in the changelog and backlog artifacts.
 
 # Testing
-- `pytest tests/test_ingestion_users.py::test_user_crud_endpoints -q`
+- `pytest`

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,8 +1,8 @@
 # Plan
 
-1. Add `role` column to `User` model and database with migration logic.
-2. Update CRUD utilities and tests to handle user roles.
-3. Implement `require_role` FastAPI dependency and secure user management endpoints.
-4. Document role-based access in `README.md` and `SECURITY.md`, and note in `CHANGELOG.md`.
-5. Run `pytest tests/test_ingestion_users.py::test_user_crud_endpoints -q`.
-6. Commit changes and open a pull request.
+1. Review current JWT timestamp handling in `server/auth.py` and identify replacements for `datetime.utcnow`.
+2. Update token generation to use `datetime.now(datetime.UTC)` ensuring timezone awareness.
+3. Extend `tests/test_auth.py` with coverage that asserts expired tokens are rejected.
+4. Run `pytest` to verify the suite passes with the timezone-aware change.
+5. Update documentation artifacts including `CHANGELOG.md`, `STATE.md`, `PATCHES.md`, and `VERIFICATIONS.md`.
+6. Commit the changes and prepare the pull request message.

--- a/STATE.md
+++ b/STATE.md
@@ -4,12 +4,10 @@
 - R3: Update documentation and changelog alongside code modifications.
 
 # Task Requirements
-- T1: Replace generic exception handlers in the client with targeted errors and logging.
-- T2: Document new client error messages in `docs/README.md` and `CHANGELOG.md`.
-- T3: Run `pytest tests/test_client_login.py::test_login_saves_token -q`.
-- T4: Add role-based access control with an admin/user `role` field on users.
-- T5: Document role usage in `README.md`, `SECURITY.md` and note in `CHANGELOG.md`.
-- T6: Run `pytest tests/test_ingestion_users.py::test_user_crud_endpoints -q`.
+- T7: Replace `datetime.utcnow` in token creation with timezone-aware `datetime.now(datetime.UTC)`.
+- T8: Add unit coverage ensuring expired tokens are rejected to validate token expiry logic.
+- T9: Run `pytest` to confirm the suite passes with the timezone-aware change.
+- T10: Update `CHANGELOG.md` with the authentication timestamp adjustment.
 
 # Cognitive Ledger
 - Cycle 1: Inspected repository structure and existing placeholder endpoints.
@@ -25,6 +23,12 @@
 - Cycle 11: Planned role-based access control and updated planning artifacts.
 - Cycle 12: Implemented role column, migration, and admin enforcement on user routes.
 - Cycle 13: Updated tests and documentation, then executed role-based CRUD tests.
+- Cycle 14: Reviewed timezone-aware JWT requirements and repository instructions for the new task.
+- Cycle 15: Refreshed planning artifacts to outline the timezone-aware authentication update.
+- Cycle 16: Replaced naive token expiration timestamps with `datetime.now(datetime.UTC)`.
+- Cycle 17: Added an expiry regression test ensuring `verify_token` rejects expired tokens.
+- Cycle 18: Updated changelog and backlog to capture the timezone-aware authentication change.
+- Cycle 19: Executed the full pytest suite to validate the update.
 
 # Decision Log
 - D1: Chose database `SELECT 1` query to verify connectivity for ingestion, users, and streaming health.
@@ -33,3 +37,4 @@
 - D4: Utilized `urllib.error` exceptions and logging for clearer client error reporting.
 - D5: Kept user-facing prints for actionable messages while logging full error details.
 - D6: Opted to verify roles against the database per request instead of encoding them into tokens for immediate revocation.
+- D7: Simulated expired tokens by monkeypatching `TOKEN_EXPIRE_SECONDS` to a negative value for deterministic testing.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
 # Backlog
-- Replace `datetime.utcnow` usage in `server/auth.py` with timezone-aware `datetime.now(datetime.UTC)`.
 - Expand metadata health check to validate API keys and authenticate with external services.
 - Include user role in JWT claims to avoid database lookup for authorization.

--- a/VERIFICATIONS.md
+++ b/VERIFICATIONS.md
@@ -2,3 +2,6 @@
 
 ## `pytest tests/test_ingestion_users.py::test_user_crud_endpoints -q`
 - Passed: see chunk `4bdaef`.
+
+## `pytest`
+- Passed: see chunk `d1919e`.

--- a/server/auth.py
+++ b/server/auth.py
@@ -38,7 +38,8 @@ def create_token(username: str) -> str:
     """Generate a JWT token for the specified user."""
     payload = {
         "sub": username,
-        "exp": datetime.datetime.utcnow() + datetime.timedelta(seconds=TOKEN_EXPIRE_SECONDS),
+        "exp": datetime.datetime.now(datetime.UTC)
+        + datetime.timedelta(seconds=TOKEN_EXPIRE_SECONDS),
     }
     return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,9 @@
+import pytest
+from fastapi import HTTPException, status
 from fastapi.testclient import TestClient
+
+from server import auth, db
 from server.app import create_app
-from server import db
 
 
 def test_login_success(temp_db):
@@ -16,3 +19,11 @@ def test_token_functions():
     from server.auth import create_token, verify_token
     token = create_token("carol")
     assert verify_token(token) == "carol"
+
+
+def test_verify_token_rejects_expired(monkeypatch):
+    monkeypatch.setattr(auth, "TOKEN_EXPIRE_SECONDS", -1)
+    token = auth.create_token("dan")
+    with pytest.raises(HTTPException) as exc_info:
+        auth.verify_token(token)
+    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
## Summary
- generate JWT expirations with `datetime.now(datetime.UTC)` so tokens carry explicit timezone context
- add a regression test that rejects expired tokens via `verify_token`
- document the authentication change in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c90a061c108322bba63a78646c9377