### PR TITLE
Ensure database sessions rollback and close on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Hardened database CRUD helpers with rollback-and-close handling, added failure
+  simulations in the test suite, and documented the session cleanup pattern.
 - Validated media ingestion paths to accept only HTTP(S) URLs or existing local files and added tests and documentation for the new checks.
 - Pinned `httpx` to `<0.24` for compatibility with Starlette 0.27.
 - Replaced placeholder ping endpoints with database-backed health checks and tests.

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,7 +1,7 @@
 # Summary
-- Added a Pydantic field validator on `IngestionRequest.path` to accept only HTTP(S) URLs or resolved existing local files while rejecting traversal attempts.
-- Expanded ingestion tests to cover valid local files and invalid URL or traversal submissions, and ensured remote URLs remain accepted.
-- Documented supported ingestion path formats and recorded the validation update in the changelog.
+- Hardened `server/db.py` CRUD helpers with try/except/finally blocks to roll back and close sessions on failure without changing their interfaces.
+- Added pytest regressions that monkeypatch the session factory to simulate commit/query errors and assert rollback plus closure semantics.
+- Documented the defensive session pattern in `docs/README.md` and noted the change in `CHANGELOG.md`.
 
 # Testing
 - `pytest`

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,7 +1,6 @@
 # Plan
 
-1. Review the existing ingestion payload validation and identify edge cases for URLs, missing files, and traversal attempts.
-2. Implement a Pydantic validator on `IngestionRequest.path` to accept only HTTP(S) URLs or existing local files without traversal segments.
-3. Expand `tests/test_ingestion_users.py` with cases covering valid URLs, valid files, and representative invalid inputs.
-4. Document supported ingestion path formats in `docs/README.md` and note the update in `CHANGELOG.md`.
-5. Run `pytest` and refresh project artifacts (`STATE.md`, `PATCHES.md`, `VERIFICATIONS.md`, `TODO.md`).
+1. Refactor database CRUD helpers in `server/db.py` to use try/except/finally blocks (or helper context) so sessions roll back and close on error without changing public interfaces.
+2. Introduce regression tests that monkeypatch the session factory to simulate commit/query failures and assert rollback/close behavior alongside existing CRUD coverage.
+3. Document the defensive session handling approach in the appropriate documentation and summarize the change in `CHANGELOG.md`.
+4. Execute `pytest` to confirm all tests pass and update project artifacts (`STATE.md`, `PATCHES.md`, `VERIFICATIONS.md`, `TODO.md`).

--- a/STATE.md
+++ b/STATE.md
@@ -8,6 +8,10 @@
 - T22: Expand tests to cover valid and invalid ingestion paths for both remote URLs and local files.
 - T23: Document supported ingestion path formats in `docs/README.md`.
 - T24: Record the validation update in `CHANGELOG.md` and ensure `pytest` passes.
+- T25: Wrap database CRUD operations with safe session management to guarantee rollback and closure on errors.
+- T26: Add tests that simulate database failures and confirm sessions are closed and rolled back appropriately.
+- T27: Document the database error-handling approach for future contributors.
+- T28: Update `CHANGELOG.md` and ensure `pytest` passes.
 
 # Cognitive Ledger
 - Cycle 1: Inspected repository structure and existing placeholder endpoints.
@@ -45,6 +49,11 @@
 - Cycle 33: Expanded ingestion tests with valid local files and invalid URL and traversal scenarios.
 - Cycle 34: Documented ingestion path requirements and updated the changelog entry.
 - Cycle 35: Ran the pytest suite to verify the ingestion validation and tests.
+- Cycle 36: Captured the session cleanup requirements and refreshed planning artifacts for the database reliability work.
+- Cycle 37: Refactored `server/db.py` CRUD helpers to wrap sessions in try/except/finally blocks with rollback on failure.
+- Cycle 38: Added regression tests that monkeypatch sessions to simulate commit and query failures, asserting rollback and closure.
+- Cycle 39: Documented the session handling pattern and updated the changelog entry.
+- Cycle 40: Executed the full pytest suite to verify the defensive session handling changes.
 
 # Decision Log
 - D1: Chose database `SELECT 1` query to verify connectivity for ingestion, users, and streaming health.
@@ -57,3 +66,4 @@
 - D8: Moved role enforcement to rely on signed JWT claims to eliminate authorization-time database queries while preserving expiry-based revocation.
 - D9: Queried the Sonarr and Radarr system status endpoints asynchronously and interpreted 401/403 responses as `auth_failed` to detect invalid API keys without blocking the event loop.
 - D10: Normalized accepted local ingestion paths to resolved filesystem locations to prevent traversal and ensure consistency.
+- D11: Chose explicit try/except/finally blocks per CRUD helper to guarantee rollback and closure without altering existing interfaces.

--- a/VERIFICATIONS.md
+++ b/VERIFICATIONS.md
@@ -1,4 +1,4 @@
 # Verification
 
 ## `pytest`
-- Passed: see chunk `a2977c`.
+- Passed: see chunk `cb4ed5`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,15 @@ also be provided when using metadata synchronization.
   invalid JSON response`. Review the message to resolve network issues,
   credentials, or file permissions.
 
+## Database Sessions
+
+`server/db.py` wraps every CRUD helper in `try/except/finally` blocks so that
+each session rolls back and closes when an operation fails. This guarantees
+that failed transactions do not leak connections or leave partial writes. When
+adding new queries, follow the same pattern by retrieving a session with
+`db.get_session()` and closing it in a `finally` clause or via a context manager
+that performs the cleanup.
+
 ## Media Ingestion
 
 The `POST /ingestion/` endpoint stores media metadata. The `path` field must be

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,4 +1,5 @@
 import bcrypt
+import pytest
 from server import db
 
 
@@ -8,3 +9,62 @@ def test_add_and_get_user(temp_db):
     assert retrieved.username == user.username
     assert db.get_password_hash("alice") == user.password_hash
     assert bcrypt.checkpw(b"password", retrieved.password_hash.encode())
+
+
+def test_add_user_rolls_back_and_closes_on_failure(monkeypatch):
+    sessions = []
+
+    class FaultySession:
+        def __init__(self):
+            self.closed = False
+            self.rollback_called = False
+
+        def add(self, _obj):
+            pass
+
+        def commit(self):
+            raise RuntimeError("boom")
+
+        def refresh(self, _obj):
+            pass
+
+        def rollback(self):
+            self.rollback_called = True
+
+        def close(self):
+            self.closed = True
+
+    def fake_get_session():
+        session = FaultySession()
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(db, "get_session", fake_get_session)
+
+    with pytest.raises(RuntimeError):
+        db.add_user("bob", "password")
+
+    session = sessions[0]
+    assert session.rollback_called
+    assert session.closed
+
+
+def test_get_user_closes_session_on_failure(monkeypatch):
+    class ExplodingSession:
+        def __init__(self):
+            self.closed = False
+
+        def scalar(self, _stmt):
+            raise RuntimeError("boom")
+
+        def close(self):
+            self.closed = True
+
+    session = ExplodingSession()
+
+    monkeypatch.setattr(db, "get_session", lambda: session)
+
+    with pytest.raises(RuntimeError):
+        db.get_user("carol")
+
+    assert session.closed


### PR DESCRIPTION
## Summary
- wrap the SQLAlchemy CRUD helpers with try/except/finally blocks so sessions roll back and close on failure
- add pytest coverage that monkeypatches the session factory to simulate commit/query failures and assert cleanup
- document the defensive pattern in docs/README.md and record the change in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c92e2175f88322935ce66b093a22fc