### PR TITLE
Add mocked integration tests for Sonarr and Radarr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Added mocked Sonarr and Radarr integration tests that verify request URLs, headers, and RequestError propagation without hitting external services.
 - Warn loudly when the JWT signing secret retains the default placeholder,
   covering startup checks with tests and updated documentation.
 - Hardened database CRUD helpers with rollback-and-close handling, added failure

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,7 +1,7 @@
 # Summary
-- Added configuration helpers that resolve the JWT secret, emit a critical warning when it matches the insecure default, and wired the check into auth and app startup.
-- Extended the application tests to assert the default secret triggers the warning while a custom secret remains silent.
-- Documented the secret configuration expectations in the READMEs and noted the change in the changelog.
+- Added Radarr integration pytest coverage that monkeypatches `httpx` to assert request URLs, headers, payloads, and RequestError propagation.
+- Added matching Sonarr integration tests validating the `/api/v3` calls, headers, and error handling without external requests.
+- Documented the mocked integration testing approach in `docs/README.md` and recorded the change in the changelog.
 
 # Testing
 - `pytest`

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,6 +1,6 @@
 # Plan
 
-1. Add a configuration helper that resolves the effective JWT secret, warns when it remains the insecure default, and integrate the check into server startup and auth secret selection.
-2. Extend the pytest suite to capture the warning for the default secret and confirm silence when a custom secret is provided.
-3. Document the secret requirements in the READMEs, summarize the change in the changelog, and refresh project artifacts before running pytest.
-4. Execute `pytest` to validate the behavior and update `STATE.md`, `PATCHES.md`, `VERIFICATIONS.md`, and related artifacts.
+1. Inspect the Sonarr and Radarr integration helpers to catalog expected URLs, headers, and error propagation behavior.
+2. Add pytest modules that monkeypatch `httpx` calls to assert the integrations send the correct requests and raise `RequestError` on failures for both success and error paths.
+3. Document the mocked integration test strategy in `docs/README.md` and summarize the additions in `CHANGELOG.md`.
+4. Execute `pytest` to verify the new tests and update `STATE.md`, `PATCHES.md`, `VERIFICATIONS.md`, and related artifacts.

--- a/STATE.md
+++ b/STATE.md
@@ -4,18 +4,10 @@
 - R3: Update documentation and changelog alongside code modifications.
 
 # Task Requirements
-- T21: Validate ingestion paths as either HTTP(S) URLs or existing local files without traversal segments.
-- T22: Expand tests to cover valid and invalid ingestion paths for both remote URLs and local files.
-- T23: Document supported ingestion path formats in `docs/README.md`.
-- T24: Record the validation update in `CHANGELOG.md` and ensure `pytest` passes.
-- T25: Wrap database CRUD operations with safe session management to guarantee rollback and closure on errors.
-- T26: Add tests that simulate database failures and confirm sessions are closed and rolled back appropriately.
-- T27: Document the database error-handling approach for future contributors.
-- T28: Update `CHANGELOG.md` and ensure `pytest` passes.
-- T29: Warn or exit when the JWT secret remains the default value on startup.
-- T30: Add tests covering default versus custom JWT secret handling.
-- T31: Document JWT secret configuration expectations in the READMEs.
-- T32: Update `CHANGELOG.md` and run `pytest`.
+- T33: Add Radarr integration tests that verify header construction, success responses, and RequestError propagation.
+- T34: Add Sonarr integration tests that verify header construction, success responses, and RequestError propagation.
+- T35: Document the mocked integration testing approach in `docs/README.md`.
+- T36: Summarize the test additions in `CHANGELOG.md` and confirm `pytest` passes.
 
 # Cognitive Ledger
 - Cycle 1: Inspected repository structure and existing placeholder endpoints.
@@ -64,7 +56,16 @@
 - Cycle 44: Documented the secret expectations in the READMEs and updated the changelog entry.
 - Cycle 45: Ran the full pytest suite to validate the warning behavior.
 
+- Cycle 46: Reviewed Sonarr and Radarr integrations plus repository guidelines to scope HTTP mocking tests.
+
+- Cycle 47: Added Radarr integration tests that verify request URLs, headers, and error propagation via monkeypatched `httpx` calls.
+- Cycle 48: Added Sonarr integration tests covering success paths, headers, and RequestError propagation with mocked HTTP calls.
+- Cycle 49: Documented the mocked integration testing strategy and summarized the update in the changelog.
+
+- Cycle 50: Executed the full pytest suite to verify the mocked integration tests.
+
 # Decision Log
+- D13: Validated Sonarr and Radarr helpers by monkeypatching `httpx` calls so tests assert URL/header contracts without external requests.
 - D1: Chose database `SELECT 1` query to verify connectivity for ingestion, users, and streaming health.
 - D2: Implemented HTTP HEAD requests to Sonarr and Radarr for metadata health without requiring sync commands.
 - D3: Expanded existing test rather than adding new functions to match execution command.

--- a/VERIFICATIONS.md
+++ b/VERIFICATIONS.md
@@ -1,4 +1,4 @@
 # Verification
 
 ## `pytest`
-- Passed: see chunk `24ae91`.
+- Passed: see chunk `d4a665`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,10 @@ must also be provided when using metadata synchronization.
   invalid JSON response`. Review the message to resolve network issues,
   credentials, or file permissions.
 
+## Testing
+
+`tests/test_sonarr.py` and `tests/test_radarr.py` monkeypatch `httpx` so the Sonarr and Radarr integrations stay deterministic. The tests assert that each helper targets the `/api/v3` endpoints, includes `X-Api-Key` headers when set, and re-raises `httpx.RequestError` for failures. Follow this pattern for new service clients to avoid contacting real servers during the suite.
+
 ## Database Sessions
 
 `server/db.py` wraps every CRUD helper in `try/except/finally` blocks so that

--- a/tests/test_radarr.py
+++ b/tests/test_radarr.py
@@ -1,0 +1,107 @@
+import httpx
+import pytest
+
+from server.integrations import radarr
+
+
+def test_headers_include_api_key(monkeypatch):
+    monkeypatch.setattr(radarr, "RADARR_API_KEY", "radarr-key")
+    assert radarr._headers() == {"X-Api-Key": "radarr-key"}
+
+
+def test_headers_omit_empty_key(monkeypatch):
+    monkeypatch.setattr(radarr, "RADARR_API_KEY", "")
+    assert radarr._headers() == {}
+
+
+def test_get_movies_requests_expected_url_and_headers(monkeypatch):
+    monkeypatch.setattr(radarr, "RADARR_URL", "http://radarr.test")
+    monkeypatch.setattr(radarr, "RADARR_API_KEY", "test-key")
+
+    call_log = {}
+
+    class DummyResponse:
+        def raise_for_status(self):
+            call_log["raised"] = True
+
+        def json(self):
+            return [
+                {"id": 42, "title": "Example"},
+            ]
+
+    def fake_get(url, *, headers=None, timeout=None):
+        call_log["url"] = url
+        call_log["headers"] = dict(headers or {})
+        call_log["timeout"] = timeout
+        return DummyResponse()
+
+    monkeypatch.setattr(radarr.httpx, "get", fake_get)
+
+    payload = radarr.get_movies()
+
+    assert payload == [{"id": 42, "title": "Example"}]
+    assert call_log["url"] == "http://radarr.test/api/v3/movie"
+    assert call_log["headers"] == {"X-Api-Key": "test-key"}
+    assert call_log["timeout"] == 10
+    assert call_log["raised"] is True
+
+
+def test_get_movies_propagates_request_error(monkeypatch):
+    monkeypatch.setattr(radarr, "RADARR_URL", "http://radarr.test")
+    monkeypatch.setattr(radarr, "RADARR_API_KEY", "")
+
+    def fake_get(url, *, headers=None, timeout=None):
+        assert url == "http://radarr.test/api/v3/movie"
+        assert headers == {}
+        assert timeout == 10
+        raise httpx.RequestError("boom", request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(radarr.httpx, "get", fake_get)
+
+    with pytest.raises(httpx.RequestError):
+        radarr.get_movies()
+
+
+def test_refresh_movies_posts_expected_payload(monkeypatch):
+    monkeypatch.setattr(radarr, "RADARR_URL", "http://radarr.test")
+    monkeypatch.setattr(radarr, "RADARR_API_KEY", "refresh-key")
+
+    call_log = {}
+
+    class DummyResponse:
+        def raise_for_status(self):
+            call_log["raised"] = True
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        call_log["url"] = url
+        call_log["json"] = dict(json or {})
+        call_log["headers"] = dict(headers or {})
+        call_log["timeout"] = timeout
+        return DummyResponse()
+
+    monkeypatch.setattr(radarr.httpx, "post", fake_post)
+
+    radarr.refresh_movies()
+
+    assert call_log["url"] == "http://radarr.test/api/v3/command"
+    assert call_log["json"] == {"name": "RefreshMovie"}
+    assert call_log["headers"] == {"X-Api-Key": "refresh-key"}
+    assert call_log["timeout"] == 10
+    assert call_log["raised"] is True
+
+
+def test_refresh_movies_propagates_request_error(monkeypatch):
+    monkeypatch.setattr(radarr, "RADARR_URL", "http://radarr.test")
+    monkeypatch.setattr(radarr, "RADARR_API_KEY", "")
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        assert url == "http://radarr.test/api/v3/command"
+        assert json == {"name": "RefreshMovie"}
+        assert headers == {}
+        assert timeout == 10
+        raise httpx.RequestError("nope", request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(radarr.httpx, "post", fake_post)
+
+    with pytest.raises(httpx.RequestError):
+        radarr.refresh_movies()

--- a/tests/test_sonarr.py
+++ b/tests/test_sonarr.py
@@ -1,0 +1,107 @@
+import httpx
+import pytest
+
+from server.integrations import sonarr
+
+
+def test_headers_include_api_key(monkeypatch):
+    monkeypatch.setattr(sonarr, "SONARR_API_KEY", "sonarr-key")
+    assert sonarr._headers() == {"X-Api-Key": "sonarr-key"}
+
+
+def test_headers_omit_empty_key(monkeypatch):
+    monkeypatch.setattr(sonarr, "SONARR_API_KEY", "")
+    assert sonarr._headers() == {}
+
+
+def test_get_series_requests_expected_url_and_headers(monkeypatch):
+    monkeypatch.setattr(sonarr, "SONARR_URL", "http://sonarr.test")
+    monkeypatch.setattr(sonarr, "SONARR_API_KEY", "test-key")
+
+    call_log = {}
+
+    class DummyResponse:
+        def raise_for_status(self):
+            call_log["raised"] = True
+
+        def json(self):
+            return [
+                {"id": 7, "title": "Example Series"},
+            ]
+
+    def fake_get(url, *, headers=None, timeout=None):
+        call_log["url"] = url
+        call_log["headers"] = dict(headers or {})
+        call_log["timeout"] = timeout
+        return DummyResponse()
+
+    monkeypatch.setattr(sonarr.httpx, "get", fake_get)
+
+    payload = sonarr.get_series()
+
+    assert payload == [{"id": 7, "title": "Example Series"}]
+    assert call_log["url"] == "http://sonarr.test/api/v3/series"
+    assert call_log["headers"] == {"X-Api-Key": "test-key"}
+    assert call_log["timeout"] == 10
+    assert call_log["raised"] is True
+
+
+def test_get_series_propagates_request_error(monkeypatch):
+    monkeypatch.setattr(sonarr, "SONARR_URL", "http://sonarr.test")
+    monkeypatch.setattr(sonarr, "SONARR_API_KEY", "")
+
+    def fake_get(url, *, headers=None, timeout=None):
+        assert url == "http://sonarr.test/api/v3/series"
+        assert headers == {}
+        assert timeout == 10
+        raise httpx.RequestError("boom", request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(sonarr.httpx, "get", fake_get)
+
+    with pytest.raises(httpx.RequestError):
+        sonarr.get_series()
+
+
+def test_refresh_series_posts_expected_payload(monkeypatch):
+    monkeypatch.setattr(sonarr, "SONARR_URL", "http://sonarr.test")
+    monkeypatch.setattr(sonarr, "SONARR_API_KEY", "refresh-key")
+
+    call_log = {}
+
+    class DummyResponse:
+        def raise_for_status(self):
+            call_log["raised"] = True
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        call_log["url"] = url
+        call_log["json"] = dict(json or {})
+        call_log["headers"] = dict(headers or {})
+        call_log["timeout"] = timeout
+        return DummyResponse()
+
+    monkeypatch.setattr(sonarr.httpx, "post", fake_post)
+
+    sonarr.refresh_series()
+
+    assert call_log["url"] == "http://sonarr.test/api/v3/command"
+    assert call_log["json"] == {"name": "RefreshSeries"}
+    assert call_log["headers"] == {"X-Api-Key": "refresh-key"}
+    assert call_log["timeout"] == 10
+    assert call_log["raised"] is True
+
+
+def test_refresh_series_propagates_request_error(monkeypatch):
+    monkeypatch.setattr(sonarr, "SONARR_URL", "http://sonarr.test")
+    monkeypatch.setattr(sonarr, "SONARR_API_KEY", "")
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        assert url == "http://sonarr.test/api/v3/command"
+        assert json == {"name": "RefreshSeries"}
+        assert headers == {}
+        assert timeout == 10
+        raise httpx.RequestError("nope", request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(sonarr.httpx, "post", fake_post)
+
+    with pytest.raises(httpx.RequestError):
+        sonarr.refresh_series()


### PR DESCRIPTION
## Summary
- add pytest coverage for the Radarr helper verifying headers, success payloads, and RequestError propagation via mocked httpx calls
- add matching Sonarr helper tests and document the deterministic mocking pattern in the docs
- record the new coverage in the changelog and refresh repository artifacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c945c2836c83228f2f42ffad8764cb