### PR TITLE
Adopt pre-commit formatting and CI linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure
+
+      - name: Run pytest
+        run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        args: ["--line-length=88"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        args: ["--max-line-length=88", "--extend-ignore=E203"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Adopted `black` and `flake8` via `pre-commit`, reformatted the codebase,
+  and resolved lint issues.
+- Added a GitHub Actions workflow to run pre-commit checks and `pytest` on
+  pushes and pull requests.
 - Added mocked Sonarr and Radarr integration tests that verify request URLs, headers, and RequestError propagation without hitting external services.
 - Warn loudly when the JWT signing secret retains the default placeholder,
   covering startup checks with tests and updated documentation.

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,7 +1,8 @@
 # Summary
-- Added Radarr integration pytest coverage that monkeypatches `httpx` to assert request URLs, headers, payloads, and RequestError propagation.
-- Added matching Sonarr integration tests validating the `/api/v3` calls, headers, and error handling without external requests.
-- Documented the mocked integration testing approach in `docs/README.md` and recorded the change in the changelog.
+- Adopted `pre-commit` with `black` and `flake8`, added the required dependencies, and reformatted the repository to satisfy the hooks.
+- Created a GitHub Actions workflow that installs dependencies, runs the pre-commit lint checks, and executes `pytest` on pushes and pull requests.
+- Updated the changelog to summarize the new tooling and automation.
 
 # Testing
+- `pre-commit run --all-files`
 - `pytest`

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,6 +1,6 @@
 # Plan
 
-1. Inspect the Sonarr and Radarr integration helpers to catalog expected URLs, headers, and error propagation behavior.
-2. Add pytest modules that monkeypatch `httpx` calls to assert the integrations send the correct requests and raise `RequestError` on failures for both success and error paths.
-3. Document the mocked integration test strategy in `docs/README.md` and summarize the additions in `CHANGELOG.md`.
-4. Execute `pytest` to verify the new tests and update `STATE.md`, `PATCHES.md`, `VERIFICATIONS.md`, and related artifacts.
+1. Review repository tooling expectations and inventory formatting or linting gaps that `black`, `flake8`, and `pre-commit` must cover.
+2. Add lightweight dependencies plus a `.pre-commit-config.yaml` that wires `black` and `flake8`, then run the hooks to format and fix violations.
+3. Introduce a GitHub Actions workflow that installs dependencies, runs `pre-commit` checks, and executes `pytest` for regression coverage.
+4. Update documentation artifacts (`CHANGELOG.md`, `STATE.md`, `PATCHES.md`, `VERIFICATIONS.md`) to reflect the new tooling and verification steps.

--- a/STATE.md
+++ b/STATE.md
@@ -4,10 +4,10 @@
 - R3: Update documentation and changelog alongside code modifications.
 
 # Task Requirements
-- T33: Add Radarr integration tests that verify header construction, success responses, and RequestError propagation.
-- T34: Add Sonarr integration tests that verify header construction, success responses, and RequestError propagation.
-- T35: Document the mocked integration testing approach in `docs/README.md`.
-- T36: Summarize the test additions in `CHANGELOG.md` and confirm `pytest` passes.
+- T37: Configure `pre-commit` with `black` and `flake8` to enforce repository style.
+- T38: Format the codebase and resolve lint violations uncovered by the new hooks.
+- T39: Add continuous integration that executes linting and `pytest` for every push and pull request.
+- T40: Verify `pre-commit` and `pytest` pass locally to satisfy the new automation.
 
 # Cognitive Ledger
 - Cycle 1: Inspected repository structure and existing placeholder endpoints.
@@ -64,8 +64,13 @@
 
 - Cycle 50: Executed the full pytest suite to verify the mocked integration tests.
 
+- Cycle 51: Reviewed repository tooling requirements, refreshed the plan, and outlined the linting automation approach.
+- Cycle 52: Added `black`, `flake8`, and `pre-commit` dependencies plus configuration, then ran the hooks to reformat the codebase.
+- Cycle 53: Resolved a `flake8` import warning and re-ran `pre-commit` to confirm clean linting results.
+- Cycle 54: Introduced a GitHub Actions workflow that installs dependencies, runs `pre-commit`, and executes `pytest`.
+- Cycle 55: Updated the changelog to capture the tooling changes and ran the full pytest suite.
+
 # Decision Log
-- D13: Validated Sonarr and Radarr helpers by monkeypatching `httpx` calls so tests assert URL/header contracts without external requests.
 - D1: Chose database `SELECT 1` query to verify connectivity for ingestion, users, and streaming health.
 - D2: Implemented HTTP HEAD requests to Sonarr and Radarr for metadata health without requiring sync commands.
 - D3: Expanded existing test rather than adding new functions to match execution command.
@@ -78,3 +83,5 @@
 - D10: Normalized accepted local ingestion paths to resolved filesystem locations to prevent traversal and ensure consistency.
 - D11: Chose explicit try/except/finally blocks per CRUD helper to guarantee rollback and closure without altering existing interfaces.
 - D12: Logged a critical warning for the default JWT secret instead of exiting to preserve simple local development while flagging insecure deployments.
+- D13: Validated Sonarr and Radarr helpers by monkeypatching `httpx` calls so tests assert URL/header contracts without external requests.
+- D14: Standardized formatting and linting by adopting `pre-commit` with `black` and `flake8`, and mirrored the workflow in GitHub Actions.

--- a/VERIFICATIONS.md
+++ b/VERIFICATIONS.md
@@ -1,4 +1,7 @@
 # Verification
 
+## `pre-commit run --all-files`
+- Passed: see chunk `b8865f`.
+
 ## `pytest`
-- Passed: see chunk `d4a665`.
+- Passed: see chunk `100c97`.

--- a/client/main.py
+++ b/client/main.py
@@ -46,7 +46,9 @@ def parse_args() -> argparse.Namespace:
     subparsers.add_parser("ping", help="Check server availability")
     subparsers.add_parser("sync", help="Synchronize metadata")
     subparsers.add_parser("list", help="List available media items")
-    login_parser = subparsers.add_parser("login", help="Obtain and optionally save a JWT token")
+    login_parser = subparsers.add_parser(
+        "login", help="Obtain and optionally save a JWT token"
+    )
     login_parser.add_argument("username", help="Account username")
     login_parser.add_argument("password", help="Account password")
     login_parser.add_argument(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ pytest
 httpx<0.24
 PyYAML
 bcrypt
+black
+flake8
+pre-commit

--- a/server/auth.py
+++ b/server/auth.py
@@ -56,15 +56,21 @@ def verify_token(token: str) -> TokenClaims:
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
     except jwt.PyJWTError as exc:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from exc
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        ) from exc
     username = payload.get("sub")
     role = payload.get("role")
     if username is None or role is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload"
+        )
     return TokenClaims(username=username, role=role)
 
 
-def token_required(credentials: HTTPAuthorizationCredentials = Depends(security)) -> TokenClaims:
+def token_required(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> TokenClaims:
     """FastAPI dependency that validates a bearer token."""
     return verify_token(credentials.credentials)
 
@@ -90,8 +96,12 @@ async def login(credentials: LoginRequest) -> dict[str, str]:
     password = credentials.password
     user = db.get_user(username)
     if user is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
+        )
     if not bcrypt.checkpw(password.encode(), user.password_hash.encode()):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
+        )
     token = create_token(user.username, user.role)
     return {"access_token": token}

--- a/server/db.py
+++ b/server/db.py
@@ -14,7 +14,9 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from .models import Base, User, MediaItem
 
-DEFAULT_DB_PATH = Path(CONFIG.get("server", {}).get("database", Path(__file__).with_name("shamash.db")))
+DEFAULT_DB_PATH = Path(
+    CONFIG.get("server", {}).get("database", Path(__file__).with_name("shamash.db"))
+)
 DB_PATH = Path(os.environ.get("SHAMASH_DB_PATH", DEFAULT_DB_PATH))
 DATABASE_URL = f"sqlite:///{DB_PATH}"
 
@@ -30,7 +32,9 @@ Base.metadata.create_all(bind=engine)
 with engine.begin() as conn:  # pragma: no cover - executed at import time
     existing = [row[1] for row in conn.execute(text("PRAGMA table_info(users)"))]
     if "role" not in existing:
-        conn.execute(text("ALTER TABLE users ADD COLUMN role STRING NOT NULL DEFAULT 'user'"))
+        conn.execute(
+            text("ALTER TABLE users ADD COLUMN role STRING NOT NULL DEFAULT 'user'")
+        )
 
 
 def get_session() -> Session:
@@ -39,6 +43,7 @@ def get_session() -> Session:
 
 
 # User management CRUD -------------------------------------------------------
+
 
 def add_user(username: str, password: str, role: str = "user") -> User:
     """Create a new user with a hashed password and role."""
@@ -74,9 +79,7 @@ def update_user_password(username: str, password: str) -> bool:
         user = session.scalar(select(User).where(User.username == username))
         if user is None:
             return False
-        user.password_hash = (
-            bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
-        )
+        user.password_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
         session.commit()
         return True
     except Exception:
@@ -110,6 +113,7 @@ def get_password_hash(username: str) -> Optional[str]:
 
 
 # Media ingestion CRUD -------------------------------------------------------
+
 
 def create_media_item(
     title: str, path: str, description: str | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,13 @@ import os
 import importlib
 import pytest
 
+
 @pytest.fixture(autouse=True)
 def temp_db(tmp_path):
     db_file = tmp_path / "test.db"
     os.environ["SHAMASH_DB_PATH"] = str(db_file)
     import server.db as db
+
     importlib.reload(db)
     yield db
     db.engine.dispose()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -28,9 +28,7 @@ def test_app_includes_routes():
     user_status = client.get("/users/ping").json()["status"]
     assert user_status in {"ok", "db_unreachable"}
 
-    stream = client.get(
-        "/stream/ping", headers={"Authorization": f"Bearer {token}"}
-    )
+    stream = client.get("/stream/ping", headers={"Authorization": f"Bearer {token}"})
     assert stream.json()["status"] in {"ok", "db_unreachable"}
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -10,13 +10,16 @@ def test_login_success(temp_db):
     db.add_user("bob", "secret")
     app = create_app()
     client = TestClient(app)
-    response = client.post("/auth/login", json={"username": "bob", "password": "secret"})
+    response = client.post(
+        "/auth/login", json={"username": "bob", "password": "secret"}
+    )
     assert response.status_code == 200
     assert "access_token" in response.json()
 
 
 def test_token_functions():
     from server.auth import create_token, verify_token
+
     token = create_token("carol", "admin")
     claims = verify_token(token)
     assert claims.username == "carol"

--- a/tests/test_client_login.py
+++ b/tests/test_client_login.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from types import SimpleNamespace
 import urllib.request
 
 from client import main

--- a/tests/test_ingestion_users.py
+++ b/tests/test_ingestion_users.py
@@ -108,9 +108,7 @@ def test_user_crud_endpoints(temp_db):
     assert resp.json()["username"] == "dave"
     assert resp.json()["role"] == "user"
 
-    resp = client.put(
-        "/users/dave", json={"password": "new"}, headers=admin_headers
-    )
+    resp = client.put("/users/dave", json={"password": "new"}, headers=admin_headers)
     assert resp.status_code == 200
 
     resp = client.delete("/users/dave", headers=admin_headers)

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -25,7 +25,8 @@ def test_stream_endpoint_serves_file(temp_db, tmp_path):
     app = create_app()
     client = TestClient(app)
     token = create_token("bob", "user")
-    response = client.get(f"/stream/{item.id}", headers={"Authorization": f"Bearer {token}"})
+    response = client.get(
+        f"/stream/{item.id}", headers={"Authorization": f"Bearer {token}"}
+    )
     assert response.status_code == 200
     assert response.content == b"hello"
-

--- a/tests/test_metadata_failure.py
+++ b/tests/test_metadata_failure.py
@@ -31,6 +31,7 @@ def _stub_metadata_client(monkeypatch, status_by_host, header_log):
 def test_metadata_sync_handles_sonarr_error(monkeypatch):
     def fail_series():
         raise httpx.RequestError("boom")
+
     monkeypatch.setattr("server.app.refresh_series", fail_series)
     app = create_app()
     client = TestClient(app)
@@ -41,8 +42,10 @@ def test_metadata_sync_handles_sonarr_error(monkeypatch):
 def test_metadata_sync_handles_radarr_error(monkeypatch):
     def fail_series():
         pass
+
     def fail_movies():
         raise httpx.RequestError("nope")
+
     monkeypatch.setattr("server.app.refresh_series", fail_series)
     monkeypatch.setattr("server.app.refresh_movies", fail_movies)
     app = create_app()


### PR DESCRIPTION
## Summary
- add pre-commit configuration with black and flake8 and include the tooling in requirements
- reformat the client, server, and test modules with black to satisfy the new hooks
- add a GitHub Actions workflow that runs the pre-commit checks and pytest on pushes and pull requests

## Testing
- pre-commit run --all-files
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c94e0ee7308322bd6d90420d0f7864