### PR TITLE
Add cross-platform release workflow and PyInstaller specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Check out repository
@@ -21,10 +25,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          python -m pip install -r requirements.txt
 
       - name: Run pre-commit
-        run: pre-commit run --all-files --show-diff-on-failure
+        run: python -m pre_commit run --all-files --show-diff-on-failure
 
       - name: Run pytest
         run: pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.artifact_suffix }} binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_suffix: linux
+            archive_extension: tar.gz
+          - os: macos-latest
+            artifact_suffix: macos
+            archive_extension: tar.gz
+          - os: windows-latest
+            artifact_suffix: windows
+            archive_extension: zip
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pyinstaller
+
+      - name: Run pytest
+        run: pytest
+
+      - name: Clean build directories
+        run: |
+          python - <<'PY'
+import shutil
+from pathlib import Path
+for path in (Path('dist') / 'pyinstaller', Path('build') / 'pyinstaller'):
+    shutil.rmtree(path, ignore_errors=True)
+PY
+
+      - name: Build client executable
+        run: pyinstaller packaging/pyinstaller/shamash_client.spec --noconfirm --distpath dist/pyinstaller --workpath build/pyinstaller
+
+      - name: Build server executable
+        run: pyinstaller packaging/pyinstaller/shamash_server.spec --noconfirm --distpath dist/pyinstaller --workpath build/pyinstaller
+
+      - name: Package archives (tar.gz)
+        if: runner.os != 'Windows'
+        run: |
+          set -eu
+          STAGING_DIR=build/release
+          rm -rf "$STAGING_DIR"
+          mkdir -p "$STAGING_DIR"
+          cp dist/pyinstaller/shamash-client "$STAGING_DIR/"
+          cp dist/pyinstaller/shamash-server "$STAGING_DIR/"
+          ARCHIVE_NAME="shamash-${GITHUB_REF_NAME}-${{ matrix.artifact_suffix }}.tar.gz"
+          tar -czf "$ARCHIVE_NAME" -C "$STAGING_DIR" .
+          mkdir -p release
+          mv "$ARCHIVE_NAME" release/
+
+      - name: Package archives (zip)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $staging = "build/release"
+          if (Test-Path $staging) { Remove-Item $staging -Recurse -Force }
+          New-Item -ItemType Directory -Path $staging | Out-Null
+          Copy-Item "dist/pyinstaller/shamash-client.exe" -Destination $staging
+          Copy-Item "dist/pyinstaller/shamash-server.exe" -Destination $staging
+          $archiveName = "shamash-$env:GITHUB_REF_NAME-${{ matrix.artifact_suffix }}.zip"
+          Compress-Archive -Path "$staging/*" -DestinationPath $archiveName
+          New-Item -ItemType Directory -Path release -Force | Out-Null
+          Move-Item $archiveName -Destination release
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: shamash-${{ matrix.artifact_suffix }}
+          path: |
+            release/shamash-${{ github.ref_name }}-${{ matrix.artifact_suffix }}.${{ matrix.archive_extension }}
+
+  publish:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Shamash ${{ github.ref_name }}
+          files: release/**/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- _No unreleased changes yet._
+
+## [0.2.0] - 2025-09-16
+- Added PyInstaller build specs and a GitHub Actions release workflow that tests, packages, and publishes binaries for Linux, macOS, and Windows.
+- Documented the automated release process in the README files to guide tagging and local builds.
 - Adopted `black` and `flake8` via `pre-commit`, reformatted the codebase,
   and resolved lint issues.
 - Added a GitHub Actions workflow to run pre-commit checks and `pytest` on
@@ -64,6 +69,7 @@ All notable changes to this project will be documented in this file.
 - Added directory structure, testing workflow and style reminder sections to
   `AGENTS.md`.
 - Documented reasons for FastAPI, JWT and SQLite usage in `POSTERITY.md`.
+
 
 ## [0.1.0] - 2025-07-01
 - Initial project structure with server, client, and documentation directories.

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,8 +1,9 @@
 # Summary
-- Adopted `pre-commit` with `black` and `flake8`, added the required dependencies, and reformatted the repository to satisfy the hooks.
-- Created a GitHub Actions workflow that installs dependencies, runs the pre-commit lint checks, and executes `pytest` on pushes and pull requests.
-- Updated the changelog to summarize the new tooling and automation.
+- Added PyInstaller spec files for the client and server that bundle the configuration directory for reproducible builds.
+- Expanded the CI workflow to a Linux, macOS, and Windows matrix and introduced a tag-triggered release pipeline that tests, packages, and uploads platform archives.
+- Documented the release workflow in the READMEs and promoted the accumulated changes into the 0.2.0 changelog entry.
 
 # Testing
-- `pre-commit run --all-files`
+- `pyinstaller packaging/pyinstaller/shamash_client.spec --noconfirm --distpath /tmp/pyi-dist --workpath /tmp/pyi-build`
+- `pyinstaller packaging/pyinstaller/shamash_server.spec --noconfirm --distpath /tmp/pyi-dist --workpath /tmp/pyi-build`
 - `pytest`

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,6 +1,6 @@
 # Plan
 
-1. Review repository tooling expectations and inventory formatting or linting gaps that `black`, `flake8`, and `pre-commit` must cover.
-2. Add lightweight dependencies plus a `.pre-commit-config.yaml` that wires `black` and `flake8`, then run the hooks to format and fix violations.
-3. Introduce a GitHub Actions workflow that installs dependencies, runs `pre-commit` checks, and executes `pytest` for regression coverage.
-4. Update documentation artifacts (`CHANGELOG.md`, `STATE.md`, `PATCHES.md`, `VERIFICATIONS.md`) to reflect the new tooling and verification steps.
+1. Capture the release packaging requirements in the state log and confirm client and server entry points for PyInstaller specs.
+2. Add deterministic PyInstaller spec files that bundle the configuration directory, then exercise a Linux build to validate the layouts.
+3. Update GitHub Actions to run pytest across Linux, macOS, and Windows and add a tag-driven release workflow that packages binaries after tests and uploads them to the GitHub Release.
+4. Document the release process in `README.md` and `docs/README.md`, create the 0.2.0 changelog entry, and refresh the verification artifacts.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ docker-compose up
 This configuration mounts the repository into the container so code changes are
 reflected immediately during development.
 
+## Release Process
+
+Follow these steps to cut a tagged release:
+
+1. Update `CHANGELOG.md` with the new version entry and commit the changes.
+2. Run `pytest` and optionally build local executables with PyInstaller to verify the specs:
+
+   ```bash
+   pyinstaller packaging/pyinstaller/shamash_client.spec --noconfirm --distpath dist/pyinstaller --workpath build/pyinstaller
+   pyinstaller packaging/pyinstaller/shamash_server.spec --noconfirm --distpath dist/pyinstaller --workpath build/pyinstaller
+   ```
+3. Create and push a semantic version tag, for example `git tag v0.2.0` followed by `git push origin v0.2.0`.
+
+Pushing a tag that matches `v*.*.*` triggers the release workflow. GitHub Actions runs `pytest` on Linux, macOS, and Windows, builds the PyInstaller executables, and uploads platform archives (e.g. `shamash-v0.2.0-linux.tar.gz`, `shamash-v0.2.0-windows.zip`) to the GitHub Release alongside the tag.
+
 ## Testing
 
 Run the test suite locally before committing changes. Tests live in the

--- a/STATE.md
+++ b/STATE.md
@@ -4,10 +4,9 @@
 - R3: Update documentation and changelog alongside code modifications.
 
 # Task Requirements
-- T37: Configure `pre-commit` with `black` and `flake8` to enforce repository style.
-- T38: Format the codebase and resolve lint violations uncovered by the new hooks.
-- T39: Add continuous integration that executes linting and `pytest` for every push and pull request.
-- T40: Verify `pre-commit` and `pytest` pass locally to satisfy the new automation.
+- T41: Build reproducible PyInstaller executables for the client and server.
+- T42: Configure GitHub Actions to test on Linux, macOS, and Windows and publish tagged releases with binaries.
+- T43: Document the release process, update the changelog, and clarify tagging instructions.
 
 # Cognitive Ledger
 - Cycle 1: Inspected repository structure and existing placeholder endpoints.
@@ -70,6 +69,18 @@
 - Cycle 54: Introduced a GitHub Actions workflow that installs dependencies, runs `pre-commit`, and executes `pytest`.
 - Cycle 55: Updated the changelog to capture the tooling changes and ran the full pytest suite.
 
+- Cycle 56: Reviewed the release packaging objectives, updated task requirements, and refreshed the planning artifact to cover PyInstaller specs and automation.
+
+- Cycle 57: Authored PyInstaller spec files for the client and server with bundled configuration data.
+
+- Cycle 58: Ran PyInstaller locally on Linux to ensure the client and server specs build successfully.
+
+- Cycle 59: Expanded continuous integration to a cross-platform matrix and scripted a tag-triggered release workflow that packages PyInstaller binaries.
+
+- Cycle 60: Documented the release workflow in the READMEs and promoted changes into the 0.2.0 changelog entry.
+
+- Cycle 61: Ran the full pytest suite to validate the release automation changes.
+
 # Decision Log
 - D1: Chose database `SELECT 1` query to verify connectivity for ingestion, users, and streaming health.
 - D2: Implemented HTTP HEAD requests to Sonarr and Radarr for metadata health without requiring sync commands.
@@ -85,3 +96,5 @@
 - D12: Logged a critical warning for the default JWT secret instead of exiting to preserve simple local development while flagging insecure deployments.
 - D13: Validated Sonarr and Radarr helpers by monkeypatching `httpx` calls so tests assert URL/header contracts without external requests.
 - D14: Standardized formatting and linting by adopting `pre-commit` with `black` and `flake8`, and mirrored the workflow in GitHub Actions.
+- D15: Stored PyInstaller specs in `packaging/pyinstaller` and resolved the project root via `SPECPATH` for portable builds.
+- D16: Packaged tag-triggered release artifacts per platform and automated publishing with GitHub Actions releases.

--- a/VERIFICATIONS.md
+++ b/VERIFICATIONS.md
@@ -1,7 +1,10 @@
 # Verification
 
-## `pre-commit run --all-files`
-- Passed: see chunk `b8865f`.
+## `pyinstaller packaging/pyinstaller/shamash_client.spec --noconfirm --distpath /tmp/pyi-dist --workpath /tmp/pyi-build`
+- Passed: see chunk `ac746f`.
+
+## `pyinstaller packaging/pyinstaller/shamash_server.spec --noconfirm --distpath /tmp/pyi-dist --workpath /tmp/pyi-build`
+- Passed: see chunk `fbbbfc`.
 
 ## `pytest`
-- Passed: see chunk `100c97`.
+- Passed: see chunk `84dc5c`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,12 @@ must also be provided when using metadata synchronization.
 
 `tests/test_sonarr.py` and `tests/test_radarr.py` monkeypatch `httpx` so the Sonarr and Radarr integrations stay deterministic. The tests assert that each helper targets the `/api/v3` endpoints, includes `X-Api-Key` headers when set, and re-raises `httpx.RequestError` for failures. Follow this pattern for new service clients to avoid contacting real servers during the suite.
 
+## Release Automation
+
+Pushing a tag that matches `v*.*.*` starts the release workflow. GitHub Actions installs the dependencies, runs `pytest` on Linux, macOS, and Windows, then invokes PyInstaller with the specs in `packaging/pyinstaller/` to build both the client and server executables. The job archives the binaries as `shamash-<tag>-linux.tar.gz`, `shamash-<tag>-macos.tar.gz`, and `shamash-<tag>-windows.zip` before publishing them to the GitHub Release.
+
+Releasing manually follows the same steps locally: run `pytest` and execute the PyInstaller specs (see the README for the exact commands) prior to tagging the repository. Once the tag is pushed, the workflow attaches the freshly built archives to the release for download.
+
 ## Database Sessions
 
 `server/db.py` wraps every CRUD helper in `try/except/finally` blocks so that

--- a/packaging/pyinstaller/shamash_client.spec
+++ b/packaging/pyinstaller/shamash_client.spec
@@ -1,0 +1,49 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from __future__ import annotations
+
+from pathlib import Path
+
+block_cipher = None
+
+SPEC_DIR = Path(SPECPATH).resolve()
+PROJECT_ROOT = SPEC_DIR.parents[1]
+CLIENT_MAIN = PROJECT_ROOT / "client" / "main.py"
+CONFIG_DIR = PROJECT_ROOT / "config"
+
+
+a = Analysis(
+    [str(CLIENT_MAIN)],
+    pathex=[str(PROJECT_ROOT)],
+    binaries=[],
+    datas=[(str(CONFIG_DIR), "config")],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="shamash-client",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/packaging/pyinstaller/shamash_server.spec
+++ b/packaging/pyinstaller/shamash_server.spec
@@ -1,0 +1,49 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from __future__ import annotations
+
+from pathlib import Path
+
+block_cipher = None
+
+SPEC_DIR = Path(SPECPATH).resolve()
+PROJECT_ROOT = SPEC_DIR.parents[1]
+SERVER_MAIN = PROJECT_ROOT / "server" / "main.py"
+CONFIG_DIR = PROJECT_ROOT / "config"
+
+
+a = Analysis(
+    [str(SERVER_MAIN)],
+    pathex=[str(PROJECT_ROOT)],
+    binaries=[],
+    datas=[(str(CONFIG_DIR), "config")],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="shamash-server",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)


### PR DESCRIPTION
## Summary
- add PyInstaller spec files that bundle the configuration directory when building the client and server executables
- expand the CI workflow to run on Linux, macOS, and Windows and add a tag-triggered release pipeline that packages and uploads binaries
- document the release process and promote the accumulated work into a 0.2.0 changelog entry

## Testing
- pyinstaller packaging/pyinstaller/shamash_client.spec --noconfirm --distpath /tmp/pyi-dist --workpath /tmp/pyi-build
- pyinstaller packaging/pyinstaller/shamash_server.spec --noconfirm --distpath /tmp/pyi-dist --workpath /tmp/pyi-build
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68c959a4a090832288a2f36fa16870c9