### PR TITLE
Restrict ingestion API to administrators

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,7 +1,7 @@
 # Summary
-- Updated `README.md` to present Shamash as production-ready, add a deployment checklist, and reference SECURITY guidance.
-- Rewrote `docs/README.md` with deployment, security, and release procedures that highlight the PyInstaller packaging assets.
-- Added an unreleased changelog entry capturing the documentation refresh and new guidance.
+- Restricted `/ingestion` endpoints in `server/app.py` by adding an admin-only dependency.
+- Updated `tests/test_ingestion_users.py` to authenticate ingestion calls with admin tokens and to assert 403 responses for unauthorized users.
+- Documented the admin ingestion requirement in `README.md` and `docs/README.md` for operators.
 
 # Testing
 - `pytest`

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,6 +1,6 @@
 # Plan
 
-1. Clarify the project positioning in `README.md`, removing the incomplete disclaimer and outlining production deployment expectations.
-2. Expand `docs/README.md` with authoritative deployment, security, and release guidance, cross-referencing `SECURITY.md` and packaging assets.
-3. Update `CHANGELOG.md` to record the documentation refresh and ensure references such as `docs/architecture.md` remain valid.
-4. Regenerate supporting artifacts (`STATE.md`, `PATCHES.md`, `VERIFICATIONS.md`) to capture the documentation updates and executed checks.
+1. Protect `/ingestion` endpoints by requiring admin credentials while preserving the existing path validation behavior.
+2. Update ingestion tests to authenticate as admin for positive cases and verify non-admin or unauthenticated calls receive 403 responses.
+3. Document the administrative requirement for ingestion workflows in README.md and docs/README.md so operators adjust credentials accordingly.
+4. Rebuild supporting artifacts (STATE.md, PATCHES.md, VERIFICATIONS.md, TODO.md) after implementing code and documentation changes.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ The server starts an HTTP API on the specified host and port.
 
 Create a user in the database using `server/db.py.add_user()` or through a
 future management endpoint. Users have a `role` of either `user` or `admin`.
-Administrative actions, such as managing other accounts, require an `admin`
-token. Obtain a token via `/auth/login` and pass it as a `Bearer` token when
-accessing protected routes such as `/stream/ping` or `/users`.
+Administrative actions, such as managing other accounts or ingesting media,
+require an `admin` token. Obtain a token via `/auth/login` and pass it as a
+`Bearer` token when accessing protected routes such as `/ingestion`,
+`/stream/ping`, or `/users`.
 
 Issued tokens embed the user's role claim so FastAPI dependencies can authorize
 requests without repeating a database lookup. The role claim is signed with the
@@ -34,10 +35,14 @@ rest of the JWT payload, ensuring tampering is rejected during verification.
 
 Shamash exposes several lightweight health checks:
 
-* `GET /ingestion/ping` &ndash; database connectivity for media ingestion.
+* `GET /ingestion/ping` &ndash; database connectivity for media ingestion (requires
+  an admin token).
 * `GET /metadata/ping` &ndash; reachability of Sonarr and Radarr plus database status.
 * `GET /users/ping` &ndash; database connectivity for user management.
 * `GET /stream/ping` &ndash; database connectivity for streaming (requires a token).
+
+All `/ingestion` endpoints require administrator credentials so that only trusted
+operators can add new media entries.
 
 ## Running the Client
 

--- a/STATE.md
+++ b/STATE.md
@@ -4,8 +4,10 @@
 - R3: Update documentation and changelog alongside code modifications.
 
 # Task Requirements
-- T44: Revise README and documentation to present production-ready guidance, including deployment, security, and release processe
-s.
+- T44: Revise README and documentation to present production-ready guidance, including deployment, security, and release processes.
+- T68: Require administrator credentials for ingestion endpoints.
+- T69: Update ingestion tests to exercise admin-only access and 403 responses for unauthorized callers.
+- T70: Document the ingestion admin requirement in README.md and docs/README.md.
 
 # Cognitive Ledger
 - Cycle 1: Inspected repository structure and existing placeholder endpoints.
@@ -86,6 +88,13 @@ s.
 - Cycle 65: Rewrote docs/README.md with deployment, security, and release procedures referencing PyInstaller packaging assets and SECURITY guidance.
 - Cycle 66: Added an unreleased changelog entry summarizing the documentation refresh.
 - Cycle 67: Executed the pytest suite to confirm documentation updates kept the project stable.
+- Cycle 68: Reviewed ingestion endpoints and related tests to scope the admin access requirement.
+- Cycle 69: Updated PLANS.md with steps for securing ingestion and documenting the change.
+- Cycle 70: Added an admin-only dependency to the `/ingestion` routes in server/app.py.
+- Cycle 71: Updated ingestion tests to authenticate with admin tokens and assert 403 responses for unauthorized callers.
+- Cycle 72: Documented the ingestion admin requirement in README.md and docs/README.md.
+- Cycle 73: Updated tests/test_app.py to authenticate ingestion health checks with an admin token.
+- Cycle 74: Ran the full pytest suite to confirm the admin-guarded ingestion behavior.
 
 # Decision Log
 - D1: Chose database `SELECT 1` query to verify connectivity for ingestion, users, and streaming health.
@@ -104,3 +113,4 @@ s.
 - D14: Standardized formatting and linting by adopting `pre-commit` with `black` and `flake8`, and mirrored the workflow in GitHub Actions.
 - D15: Stored PyInstaller specs in `packaging/pyinstaller` and resolved the project root via `SPECPATH` for portable builds.
 - D16: Packaged tag-triggered release artifacts per platform and automated publishing with GitHub Actions releases.
+- D17: Secured media ingestion by applying an admin-only dependency at the router level to cover all `/ingestion` endpoints.

--- a/VERIFICATIONS.md
+++ b/VERIFICATIONS.md
@@ -7,4 +7,4 @@
 - Passed: see chunk `fbbbfc`.
 
 ## `pytest`
-- Passed: see chunk `8fc827`.
+- Passed: see chunk `748b76`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,13 +65,13 @@ The automation consumes the specs in `packaging/pyinstaller/` to guarantee parit
 
 ## Authentication
 
-Use `/auth/login` to obtain a JWT token. Include the token in the `Authorization: Bearer` header when calling protected endpoints such as `/stream/ping`.
+Use `/auth/login` to obtain a JWT token. Include the token in the `Authorization: Bearer` header when calling protected endpoints such as `/ingestion`, `/stream/ping`, or `/users`.
 
 ## Health Checks
 
 The API exposes lightweight health endpoints:
 
-* `GET /ingestion/ping` &ndash; verifies database connectivity for media ingestion.
+* `GET /ingestion/ping` &ndash; verifies database connectivity for media ingestion (requires an admin token).
 * `GET /metadata/ping` &ndash; checks reachability of Sonarr and Radarr and the database. The endpoint performs authenticated status requests and reports `auth_failed` when API keys are missing or invalid.
 * `GET /users/ping` &ndash; verifies database connectivity for user management.
 * `GET /stream/ping` &ndash; verifies database connectivity for streaming (requires a token).
@@ -98,4 +98,4 @@ Set the `JWT_SECRET` variable or edit `config/default.yaml` to configure the sec
 
 ## Media Ingestion
 
-The `POST /ingestion/` endpoint stores media metadata. The `path` field must be either an `http://` or `https://` URL or a local filesystem path that resolves to an existing file. Local paths are expanded, resolved, and rejected when they contain traversal segments such as `..` or refer to directories or missing files. Provide fully qualified URLs for remote media to avoid validation errors.
+The `POST /ingestion/` endpoint stores media metadata. All `/ingestion` operations require administrator credentials so only trusted operators ingest media. The `path` field must be either an `http://` or `https://` URL or a local filesystem path that resolves to an existing file. Local paths are expanded, resolved, and rejected when they contain traversal segments such as `..` or refer to directories or missing files. Provide fully qualified URLs for remote media to avoid validation errors.

--- a/server/app.py
+++ b/server/app.py
@@ -18,7 +18,11 @@ from .integrations.sonarr import SONARR_API_KEY, SONARR_URL, refresh_series
 
 
 # Placeholder routers for future modules
-media_ingestion_router = APIRouter(prefix="/ingestion", tags=["ingestion"])
+media_ingestion_router = APIRouter(
+    prefix="/ingestion",
+    tags=["ingestion"],
+    dependencies=[Depends(require_role("admin"))],
+)
 metadata_sync_router = APIRouter(prefix="/metadata", tags=["metadata"])
 user_management_router = APIRouter(prefix="/users", tags=["users"])
 streaming_router = APIRouter(prefix="/stream", tags=["stream"])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -14,12 +14,14 @@ def test_app_includes_routes():
     assert "/stream/ping" in paths
     assert "/metadata/sync" in paths
 
-    db.add_user("alice", "pw")
+    db.add_user("alice", "pw", role="admin")
     token = client.post(
         "/auth/login", json={"username": "alice", "password": "pw"}
     ).json()["access_token"]
 
-    ingest = client.get("/ingestion/ping")
+    ingest = client.get(
+        "/ingestion/ping", headers={"Authorization": f"Bearer {token}"}
+    )
     assert ingest.json()["status"] in {"ok", "db_unreachable"}
 
     meta = client.get("/metadata/ping").json()

--- a/tests/test_ingestion_users.py
+++ b/tests/test_ingestion_users.py
@@ -3,12 +3,29 @@ from server.app import create_app
 from server import db
 
 
-def test_ingest_creates_item(temp_db):
+def _login(client: TestClient, username: str, password: str) -> dict[str, str]:
+    response = client.post(
+        "/auth/login", json={"username": username, "password": password}
+    )
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_admin_client() -> tuple[TestClient, dict[str, str]]:
+    db.add_user("admin", "pw", role="admin")
     app = create_app()
     client = TestClient(app)
+    admin_headers = _login(client, "admin", "pw")
+    return client, admin_headers
+
+
+def test_ingest_creates_item(temp_db):
+    client, admin_headers = _create_admin_client()
     response = client.post(
         "/ingestion/",
         json={"title": "new", "path": "http://example.com/video.mp4"},
+        headers=admin_headers,
     )
     assert response.status_code == 200
     items = db.list_media_items()
@@ -21,11 +38,11 @@ def test_ingest_accepts_local_file_path(temp_db, tmp_path):
     media_file = tmp_path / "movie.mp4"
     media_file.write_bytes(b"binary")
 
-    app = create_app()
-    client = TestClient(app)
+    client, admin_headers = _create_admin_client()
     response = client.post(
         "/ingestion/",
         json={"title": "local", "path": str(media_file)},
+        headers=admin_headers,
     )
 
     assert response.status_code == 200
@@ -37,11 +54,11 @@ def test_ingest_accepts_local_file_path(temp_db, tmp_path):
 def test_ingest_rejects_missing_local_file(temp_db, tmp_path):
     missing = tmp_path / "missing.mp4"
 
-    app = create_app()
-    client = TestClient(app)
+    client, admin_headers = _create_admin_client()
     response = client.post(
         "/ingestion/",
         json={"title": "bad", "path": str(missing)},
+        headers=admin_headers,
     )
 
     assert response.status_code == 422
@@ -51,11 +68,11 @@ def test_ingest_rejects_missing_local_file(temp_db, tmp_path):
 
 
 def test_ingest_rejects_directory_traversal(temp_db):
-    app = create_app()
-    client = TestClient(app)
+    client, admin_headers = _create_admin_client()
     response = client.post(
         "/ingestion/",
         json={"title": "bad", "path": "../etc/passwd"},
+        headers=admin_headers,
     )
 
     assert response.status_code == 422
@@ -65,17 +82,47 @@ def test_ingest_rejects_directory_traversal(temp_db):
 
 
 def test_ingest_rejects_invalid_url(temp_db):
-    app = create_app()
-    client = TestClient(app)
+    client, admin_headers = _create_admin_client()
     response = client.post(
         "/ingestion/",
         json={"title": "bad", "path": "ftp://example.com/video.mp4"},
+        headers=admin_headers,
     )
 
     assert response.status_code == 422
     detail = response.json()["detail"][0]
     assert detail["loc"][-1] == "path"
     assert "http or https" in detail["msg"]
+
+
+def test_ingest_rejects_missing_token(temp_db):
+    db.add_user("admin", "pw", role="admin")
+    app = create_app()
+    client = TestClient(app)
+
+    response = client.post(
+        "/ingestion/",
+        json={"title": "new", "path": "http://example.com/video.mp4"},
+    )
+
+    assert response.status_code == 403
+    assert db.list_media_items() == []
+
+
+def test_ingest_rejects_non_admin_role(temp_db):
+    db.add_user("user", "pw", role="user")
+    app = create_app()
+    client = TestClient(app)
+    user_headers = _login(client, "user", "pw")
+
+    response = client.post(
+        "/ingestion/",
+        json={"title": "new", "path": "http://example.com/video.mp4"},
+        headers=user_headers,
+    )
+
+    assert response.status_code == 403
+    assert db.list_media_items() == []
 
 
 def test_user_crud_endpoints(temp_db):


### PR DESCRIPTION
## Summary
- add an admin-only dependency to the `/ingestion` router
- update ingestion tests to authenticate with admin tokens and cover 403 cases
- document the administrative requirement for ingestion in the READMEs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cb9ba429548322823e55259f76e1e9